### PR TITLE
Audit wave 5: install resilience + cross-platform cleanup

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,40 +3,262 @@
   "version": "0.2.0",
   "description": "Standalone QE library — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, optional wicked-bus + wicked-brain integration.",
   "skills": [
-    { "name": "wicked-testing:plan",      "path": "skills/plan/SKILL.md",      "command": "/wicked-testing:plan" },
-    { "name": "wicked-testing:authoring", "path": "skills/authoring/SKILL.md", "command": "/wicked-testing:authoring" },
-    { "name": "wicked-testing:execution", "path": "skills/execution/SKILL.md", "command": "/wicked-testing:execution" },
-    { "name": "wicked-testing:review",    "path": "skills/review/SKILL.md",    "command": "/wicked-testing:review" },
-    { "name": "wicked-testing:insight",   "path": "skills/insight/SKILL.md",   "command": "/wicked-testing:insight" }
+    {
+      "name": "wicked-testing:acceptance-testing",
+      "path": "skills/acceptance-testing/SKILL.md",
+      "command": "/wicked-testing:acceptance-testing"
+    },
+    {
+      "name": "wicked-testing:authoring",
+      "path": "skills/authoring/SKILL.md",
+      "command": "/wicked-testing:authoring"
+    },
+    {
+      "name": "wicked-testing:browser-automation",
+      "path": "skills/browser-automation/SKILL.md",
+      "command": "/wicked-testing:browser-automation"
+    },
+    {
+      "name": "wicked-testing:execution",
+      "path": "skills/execution/SKILL.md",
+      "command": "/wicked-testing:execution"
+    },
+    {
+      "name": "wicked-testing:insight",
+      "path": "skills/insight/SKILL.md",
+      "command": "/wicked-testing:insight"
+    },
+    {
+      "name": "wicked-testing:plan",
+      "path": "skills/plan/SKILL.md",
+      "command": "/wicked-testing:plan"
+    },
+    {
+      "name": "wicked-testing:review",
+      "path": "skills/review/SKILL.md",
+      "command": "/wicked-testing:review"
+    },
+    {
+      "name": "wicked-testing:scenario-authoring",
+      "path": "skills/scenario-authoring/SKILL.md",
+      "command": "/wicked-testing:scenario-authoring"
+    },
+    {
+      "name": "wicked-testing:test-oracle",
+      "path": "skills/test-oracle/SKILL.md",
+      "command": "/wicked-testing:test-oracle"
+    },
+    {
+      "name": "wicked-testing:test-runner",
+      "path": "skills/test-runner/SKILL.md",
+      "command": "/wicked-testing:test-runner"
+    },
+    {
+      "name": "wicked-testing:test-strategy",
+      "path": "skills/test-strategy/SKILL.md",
+      "command": "/wicked-testing:test-strategy"
+    }
   ],
   "agents": [
-    { "name": "test-strategist",                "path": "agents/test-strategist.md" },
-    { "name": "test-designer",                  "path": "agents/test-designer.md" },
-    { "name": "test-automation-engineer",       "path": "agents/test-automation-engineer.md" },
-    { "name": "testability-reviewer",           "path": "agents/testability-reviewer.md" },
-    { "name": "requirements-quality-analyst",   "path": "agents/requirements-quality-analyst.md" },
-    { "name": "risk-assessor",                  "path": "agents/risk-assessor.md" },
-    { "name": "code-analyzer",                  "path": "agents/code-analyzer.md" },
-    { "name": "semantic-reviewer",              "path": "agents/semantic-reviewer.md" },
-    { "name": "contract-testing-engineer",      "path": "agents/contract-testing-engineer.md" },
-    { "name": "continuous-quality-monitor",     "path": "agents/continuous-quality-monitor.md" },
-    { "name": "production-quality-engineer",    "path": "agents/production-quality-engineer.md" },
-    { "name": "acceptance-test-writer",         "path": "agents/acceptance-test-writer.md" },
-    { "name": "acceptance-test-executor",       "path": "agents/acceptance-test-executor.md" },
-    { "name": "acceptance-test-reviewer",       "path": "agents/acceptance-test-reviewer.md" },
-    { "name": "scenario-executor",              "path": "agents/scenario-executor.md" },
-    { "name": "test-oracle",                    "path": "agents/test-oracle.md" }
+    {
+      "name": "acceptance-test-executor",
+      "path": "agents/acceptance-test-executor.md"
+    },
+    {
+      "name": "acceptance-test-reviewer",
+      "path": "agents/acceptance-test-reviewer.md"
+    },
+    {
+      "name": "acceptance-test-writer",
+      "path": "agents/acceptance-test-writer.md"
+    },
+    {
+      "name": "code-analyzer",
+      "path": "agents/code-analyzer.md"
+    },
+    {
+      "name": "continuous-quality-monitor",
+      "path": "agents/continuous-quality-monitor.md"
+    },
+    {
+      "name": "contract-testing-engineer",
+      "path": "agents/contract-testing-engineer.md"
+    },
+    {
+      "name": "production-quality-engineer",
+      "path": "agents/production-quality-engineer.md"
+    },
+    {
+      "name": "requirements-quality-analyst",
+      "path": "agents/requirements-quality-analyst.md"
+    },
+    {
+      "name": "risk-assessor",
+      "path": "agents/risk-assessor.md"
+    },
+    {
+      "name": "scenario-executor",
+      "path": "agents/scenario-executor.md"
+    },
+    {
+      "name": "semantic-reviewer",
+      "path": "agents/semantic-reviewer.md"
+    },
+    {
+      "name": "test-automation-engineer",
+      "path": "agents/test-automation-engineer.md"
+    },
+    {
+      "name": "test-designer",
+      "path": "agents/test-designer.md"
+    },
+    {
+      "name": "test-oracle",
+      "path": "agents/test-oracle.md"
+    },
+    {
+      "name": "test-strategist",
+      "path": "agents/test-strategist.md"
+    },
+    {
+      "name": "testability-reviewer",
+      "path": "agents/testability-reviewer.md"
+    },
+    {
+      "name": "a11y-test-engineer",
+      "path": "agents/specialists/a11y-test-engineer.md"
+    },
+    {
+      "name": "chaos-test-engineer",
+      "path": "agents/specialists/chaos-test-engineer.md"
+    },
+    {
+      "name": "coverage-archaeologist",
+      "path": "agents/specialists/coverage-archaeologist.md"
+    },
+    {
+      "name": "data-quality-tester",
+      "path": "agents/specialists/data-quality-tester.md"
+    },
+    {
+      "name": "e2e-orchestrator",
+      "path": "agents/specialists/e2e-orchestrator.md"
+    },
+    {
+      "name": "exploratory-tester",
+      "path": "agents/specialists/exploratory-tester.md"
+    },
+    {
+      "name": "flaky-test-hunter",
+      "path": "agents/specialists/flaky-test-hunter.md"
+    },
+    {
+      "name": "fuzz-property-engineer",
+      "path": "agents/specialists/fuzz-property-engineer.md"
+    },
+    {
+      "name": "integration-test-engineer",
+      "path": "agents/specialists/integration-test-engineer.md"
+    },
+    {
+      "name": "load-performance-engineer",
+      "path": "agents/specialists/load-performance-engineer.md"
+    },
+    {
+      "name": "localization-test-engineer",
+      "path": "agents/specialists/localization-test-engineer.md"
+    },
+    {
+      "name": "mutation-test-engineer",
+      "path": "agents/specialists/mutation-test-engineer.md"
+    },
+    {
+      "name": "observability-test-engineer",
+      "path": "agents/specialists/observability-test-engineer.md"
+    },
+    {
+      "name": "test-data-manager",
+      "path": "agents/specialists/test-data-manager.md"
+    },
+    {
+      "name": "ui-component-test-engineer",
+      "path": "agents/specialists/ui-component-test-engineer.md"
+    },
+    {
+      "name": "visual-regression-engineer",
+      "path": "agents/specialists/visual-regression-engineer.md"
+    }
   ],
   "commands": [
-    { "name": "plan",      "path": "commands/plan.md",      "slash": "/wicked-testing:plan" },
-    { "name": "authoring", "path": "commands/authoring.md", "slash": "/wicked-testing:authoring" },
-    { "name": "execution", "path": "commands/execution.md", "slash": "/wicked-testing:execution" },
-    { "name": "review",    "path": "commands/review.md",    "slash": "/wicked-testing:review" },
-    { "name": "insight",   "path": "commands/insight.md",   "slash": "/wicked-testing:insight" },
-    { "name": "setup",     "path": "commands/setup.md",     "slash": "/wicked-testing:setup" },
-    { "name": "oracle",    "path": "commands/oracle.md",    "slash": "/wicked-testing:oracle" },
-    { "name": "tasks",     "path": "commands/tasks.md",     "slash": "/wicked-testing:tasks" },
-    { "name": "stats",     "path": "commands/stats.md",     "slash": "/wicked-testing:stats" },
-    { "name": "report",    "path": "commands/report.md",    "slash": "/wicked-testing:report" }
+    {
+      "name": "acceptance",
+      "path": "commands/acceptance.md",
+      "slash": "/wicked-testing:acceptance"
+    },
+    {
+      "name": "authoring",
+      "path": "commands/authoring.md",
+      "slash": "/wicked-testing:authoring"
+    },
+    {
+      "name": "automate",
+      "path": "commands/automate.md",
+      "slash": "/wicked-testing:automate"
+    },
+    {
+      "name": "execution",
+      "path": "commands/execution.md",
+      "slash": "/wicked-testing:execution"
+    },
+    {
+      "name": "insight",
+      "path": "commands/insight.md",
+      "slash": "/wicked-testing:insight"
+    },
+    {
+      "name": "oracle",
+      "path": "commands/oracle.md",
+      "slash": "/wicked-testing:oracle"
+    },
+    {
+      "name": "plan",
+      "path": "commands/plan.md",
+      "slash": "/wicked-testing:plan"
+    },
+    {
+      "name": "report",
+      "path": "commands/report.md",
+      "slash": "/wicked-testing:report"
+    },
+    {
+      "name": "review",
+      "path": "commands/review.md",
+      "slash": "/wicked-testing:review"
+    },
+    {
+      "name": "run",
+      "path": "commands/run.md",
+      "slash": "/wicked-testing:run"
+    },
+    {
+      "name": "scenarios",
+      "path": "commands/scenarios.md",
+      "slash": "/wicked-testing:scenarios"
+    },
+    {
+      "name": "setup",
+      "path": "commands/setup.md",
+      "slash": "/wicked-testing:setup"
+    },
+    {
+      "name": "stats",
+      "path": "commands/stats.md",
+      "slash": "/wicked-testing:stats"
+    },
+    {
+      "name": "tasks",
+      "path": "commands/tasks.md",
+      "slash": "/wicked-testing:tasks"
+    }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ yarn-error.log*
 .claude/agents/
 .claude/commands/
 .claude/**/workspace/
+.claude/worktrees/
 .claude/settings.local.json
 .gemini/
 .codex/

--- a/SCENARIO-FORMAT.md
+++ b/SCENARIO-FORMAT.md
@@ -64,8 +64,10 @@ The body is structured markdown with optional `## Setup`, required `## Steps`, a
 ```bash
 # Commands to run before the test steps
 # Exit code is non-fatal — warn on failure but continue
+# Use a portable tmp dir: TMPDIR (Unix), TEMP (Windows Git Bash), fallback /tmp.
 export TEST_ENV=integration
-mkdir -p /tmp/test-artifacts
+WT_TMP="${TMPDIR:-${TEMP:-/tmp}}"
+mkdir -p "${WT_TMP}/test-artifacts"
 ```
 ```
 
@@ -106,8 +108,10 @@ curl -sf https://example.com/api/health | grep '"status":"ok"'
 ## Cleanup
 
 ```bash
-# Always runs after steps, even on failure (like a finally block)
-rm -rf /tmp/test-artifacts
+# Always runs after steps, even on failure (like a finally block).
+# Use the same portable tmp resolution as Setup.
+WT_TMP="${TMPDIR:-${TEMP:-/tmp}}"
+rm -rf "${WT_TMP}/test-artifacts"
 ```
 ```
 

--- a/agents/acceptance-test-executor.md
+++ b/agents/acceptance-test-executor.md
@@ -171,14 +171,18 @@ If wicked-bus is installed on PATH, emit progress events so downstream tools
 (wicked-garden crew gates, dashboards) can react in real time:
 
 ```bash
-# After each step completes
-wicked-bus emit --type wicked.testrun.step --domain wicked-testing \
-  --payload "{\"run_id\":\"${RUN_ID}\",\"step\":\"STEP-${N}\",\"status\":\"captured\"}" \
-  2>/dev/null || true
+# After each step completes — fire-and-forget via Python wrapper so the
+# stderr silence works on both POSIX shells and Windows Git Bash. A plain
+# `2>/dev/null || true` is Unix-only; native PowerShell drops the redirect
+# and the emit's stderr would leak into the transcript.
+python3 -c "import subprocess,sys; subprocess.run(['wicked-bus','emit','--type','wicked.testrun.step','--domain','wicked-testing','--payload','{\"run_id\":\"'+sys.argv[1]+'\",\"step\":\"STEP-'+sys.argv[2]+'\",\"status\":\"captured\"}'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)" "${RUN_ID}" "${N}" \
+  2>/dev/null \
+  || python -c "import subprocess,sys; subprocess.run(['wicked-bus','emit','--type','wicked.testrun.step','--domain','wicked-testing','--payload','{\"run_id\":\"'+sys.argv[1]+'\",\"step\":\"STEP-'+sys.argv[2]+'\",\"status\":\"captured\"}'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)" "${RUN_ID}" "${N}" \
+  || true
 ```
 
-Always use `|| true` — bus emissions are fire-and-forget. If the bus is absent
-or the emit fails, execution continues. Events are a side signal, not a gate.
+Bus emissions are fire-and-forget. If the bus is absent or the emit fails,
+execution continues. Events are a side signal, not a gate.
 
 ## Optional: Brain Lookup for Known Environment Quirks
 
@@ -186,10 +190,20 @@ If wicked-brain is present, you can query for environment-specific notes before
 executing a step (e.g., "docker compose v1 vs v2 flag differences"):
 
 ```bash
-curl -s -X POST http://localhost:${WICKED_BRAIN_PORT:-4101}/api \
-  -H "Content-Type: application/json" \
-  -d "{\"action\":\"search\",\"params\":{\"query\":\"<tool-name> <env>\",\"limit\":3}}" \
-  2>/dev/null
+# Use Python's urllib so the HTTP call is cross-platform and stderr silencing
+# works even where `2>/dev/null` does not (native PowerShell).
+python3 -c "import json,urllib.request,os; \
+  req=urllib.request.Request('http://localhost:'+os.environ.get('WICKED_BRAIN_PORT','4101')+'/api', \
+    data=json.dumps({'action':'search','params':{'query':'<tool-name> <env>','limit':3}}).encode(), \
+    headers={'Content-Type':'application/json'}); \
+  print(urllib.request.urlopen(req,timeout=2).read().decode())" \
+  2>/dev/null \
+  || python -c "import json,urllib.request,os; \
+  req=urllib.request.Request('http://localhost:'+os.environ.get('WICKED_BRAIN_PORT','4101')+'/api', \
+    data=json.dumps({'action':'search','params':{'query':'<tool-name> <env>','limit':3}}).encode(), \
+    headers={'Content-Type':'application/json'}); \
+  print(urllib.request.urlopen(req,timeout=2).read().decode())" \
+  || true
 ```
 
 Brain responses inform **how** you execute (e.g., use `docker compose` not

--- a/agents/scenario-executor.md
+++ b/agents/scenario-executor.md
@@ -68,10 +68,28 @@ Parse each `### Step N: description (cli-name)` section in order:
 1. Extract the fenced code block
 2. Identify the CLI from the step header parenthetical or code fence
 3. If CLI not available → record SKIPPED, continue
-4. Execute via Bash with timeout:
+4. Execute via Bash with timeout. Use a cross-platform tmp dir and a timeout
+   chain that degrades gracefully when neither `timeout` nor `gtimeout` is
+   on PATH (bare macOS, Windows Git Bash). A richer Node-based wrapper is
+   available in `lib/exec-with-timeout.mjs` when the caller can invoke Node
+   directly — prefer it over the shell chain when possible.
 
 ```bash
-timeout ${TIMEOUT:-120} bash -c '{step_command}' > /tmp/wt-step-${N}.stdout 2> /tmp/wt-step-${N}.stderr
+# Cross-platform tmp dir: TMPDIR (Unix), TEMP (Windows Git Bash), fallback /tmp
+WT_TMP="${TMPDIR:-${TEMP:-/tmp}}"
+
+# timeout → gtimeout (macOS coreutils) → bare (last resort; warn)
+if command -v timeout >/dev/null 2>&1; then
+  timeout "${TIMEOUT:-120}" bash -c '{step_command}' \
+    > "${WT_TMP}/wt-step-${N}.stdout" 2> "${WT_TMP}/wt-step-${N}.stderr"
+elif command -v gtimeout >/dev/null 2>&1; then
+  gtimeout "${TIMEOUT:-120}" bash -c '{step_command}' \
+    > "${WT_TMP}/wt-step-${N}.stdout" 2> "${WT_TMP}/wt-step-${N}.stderr"
+else
+  echo "warn: no timeout/gtimeout on PATH; running step without enforced timeout" >&2
+  bash -c '{step_command}' \
+    > "${WT_TMP}/wt-step-${N}.stdout" 2> "${WT_TMP}/wt-step-${N}.stderr"
+fi
 EXIT_CODE=$?
 ```
 
@@ -152,5 +170,5 @@ Evidence written to: {EVIDENCE_DIR}/evidence.json
 - **Sequential execution**: Run steps in order, don't parallelize
 - **Continue on failure**: Record FAIL but keep going to next step
 - **Setup/Cleanup always run**: Cleanup runs even if steps fail
-- **Respect timeouts**: Use `timeout` command for bash execution
+- **Respect timeouts**: Use the portable `timeout` / `gtimeout` / bare-fallback chain for bash execution, or `lib/exec-with-timeout.mjs` for Node-based callers
 - **Be honest**: Don't mark PASS if output indicates an error, even if exit code is 0

--- a/agents/test-strategist.md
+++ b/agents/test-strategist.md
@@ -45,15 +45,11 @@ so probe git via a Python one-liner that does its own stderr suppression.
 # a valid ref, so the caller never sees a non-zero exit from an absent 'main'.
 python3 -c "import subprocess; \
   refs=['main','HEAD~1']; \
-  out=''; \
-  [ (lambda r: (globals().__setitem__('out', r.stdout)) if r.returncode==0 else None)(subprocess.run(['git','diff',ref,'--stat'],capture_output=True,text=True)) for ref in refs if not out ]; \
-  print(out or 'No git diff available')" \
+  print(next((r.stdout for r in (subprocess.run(['git','diff',ref,'--stat'],capture_output=True,text=True) for ref in refs) if r.returncode==0), 'No git diff available'))" \
   2>/dev/null \
   || python -c "import subprocess; \
   refs=['main','HEAD~1']; \
-  out=''; \
-  [ (lambda r: (globals().__setitem__('out', r.stdout)) if r.returncode==0 else None)(subprocess.run(['git','diff',ref,'--stat'],capture_output=True,text=True)) for ref in refs if not out ]; \
-  print(out or 'No git diff available')"
+  print(next((r.stdout for r in (subprocess.run(['git','diff',ref,'--stat'],capture_output=True,text=True) for ref in refs) if r.returncode==0), 'No git diff available'))"
 
 # Name-only list — same idea, returns empty string if the ref is absent.
 python3 -c "import subprocess; r=subprocess.run(['git','diff','main','--name-only'],capture_output=True,text=True); print(r.stdout)" \

--- a/agents/test-strategist.md
+++ b/agents/test-strategist.md
@@ -37,18 +37,46 @@ You generate aggressive, comprehensive test strategies for wicked-testing. Your 
 **Input**: Actual changes implemented.
 **Goal**: Recalibrate the test strategy based on what actually changed.
 
-Run this step always:
+Run this step always. Native PowerShell on Windows does not grok `2>/dev/null`,
+so probe git via a Python one-liner that does its own stderr suppression.
+
 ```bash
-git diff main --stat 2>/dev/null || git diff HEAD~1 --stat 2>/dev/null || echo "No git diff available"
-git diff main --name-only 2>/dev/null || true
+# Portable git-diff probes — Python wrapper swallows stderr and picks
+# a valid ref, so the caller never sees a non-zero exit from an absent 'main'.
+python3 -c "import subprocess; \
+  refs=['main','HEAD~1']; \
+  out=''; \
+  [ (lambda r: (globals().__setitem__('out', r.stdout)) if r.returncode==0 else None)(subprocess.run(['git','diff',ref,'--stat'],capture_output=True,text=True)) for ref in refs if not out ]; \
+  print(out or 'No git diff available')" \
+  2>/dev/null \
+  || python -c "import subprocess; \
+  refs=['main','HEAD~1']; \
+  out=''; \
+  [ (lambda r: (globals().__setitem__('out', r.stdout)) if r.returncode==0 else None)(subprocess.run(['git','diff',ref,'--stat'],capture_output=True,text=True)) for ref in refs if not out ]; \
+  print(out or 'No git diff available')"
+
+# Name-only list — same idea, returns empty string if the ref is absent.
+python3 -c "import subprocess; r=subprocess.run(['git','diff','main','--name-only'],capture_output=True,text=True); print(r.stdout)" \
+  2>/dev/null \
+  || python -c "import subprocess; r=subprocess.run(['git','diff','main','--name-only'],capture_output=True,text=True); print(r.stdout)"
 ```
 
 ## Process
 
 ### 1. Find Existing Tests
 
+Bash `find . -name` and stderr-silencing with `2>/dev/null` are Unix-only and
+unreliable on Windows Git Bash / PowerShell. Use Python's `pathlib.rglob`
+instead — it walks the tree on every platform and lets us filter cheaply.
+
 ```bash
-find . -name "*test*" -o -name "*spec*" 2>/dev/null | head -50
+python3 -c "import pathlib; \
+  hits=[str(p) for p in pathlib.Path('.').rglob('*') if p.is_file() and ('test' in p.name.lower() or 'spec' in p.name.lower())][:50]; \
+  print('\n'.join(hits))" \
+  2>/dev/null \
+  || python -c "import pathlib; \
+  hits=[str(p) for p in pathlib.Path('.').rglob('*') if p.is_file() and ('test' in p.name.lower() or 'spec' in p.name.lower())][:50]; \
+  print('\n'.join(hits))"
 ```
 
 ### 2. Classify Change Type and Surface Area

--- a/commands/stats.md
+++ b/commands/stats.md
@@ -42,12 +42,18 @@ sqlite3 -json ".wicked-testing/wicked-testing.db" "
 "
 ```
 
-**JSON-only mode** — count files in each directory:
+**JSON-only mode** — count files in each directory via Python so the glob,
+stderr suppression, and line-count are all cross-platform (Windows Git Bash
+does not ship `wc`, and `ls ... 2>/dev/null` leaks on some shells):
+
 ```bash
-for dir in projects strategies scenarios runs verdicts tasks; do
-  count=$(ls .wicked-testing/$dir/*.json 2>/dev/null | wc -l)
-  echo "$dir: $count"
-done
+python3 -c "import pathlib; \
+  [print(f'{d}: {len(list(pathlib.Path(\".wicked-testing\",d).glob(\"*.json\")))}') \
+    for d in ['projects','strategies','scenarios','runs','verdicts','tasks']]" \
+  2>/dev/null \
+  || python -c "import pathlib; \
+  [print(f'{d}: {len(list(pathlib.Path(\".wicked-testing\",d).glob(\"*.json\")))}') \
+    for d in ['projects','strategies','scenarios','runs','verdicts','tasks']]"
 ```
 
 Annotate as `"mode": "json-only"` in the output.

--- a/install.mjs
+++ b/install.mjs
@@ -4,7 +4,7 @@
 
 import {
   existsSync, mkdirSync, mkdtempSync, cpSync, readdirSync, rmSync,
-  readFileSync, writeFileSync,
+  readFileSync, writeFileSync, accessSync, statSync, constants as FS_CONST,
 } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { homedir, tmpdir } from "node:os";
@@ -18,14 +18,84 @@ const PKG = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
 const VERSION = PKG.version;
 const INSTALLED_MARKER = ".wicked-testing-version";
 
+// Per-CLI target spec. `identityMarkers` is any of-list of filenames/dirs
+// that must exist inside the CLI's home-relative root before we'll install
+// — prevents us writing into an unrelated `~/.claude/` that a different
+// tool created. `isolationTier` tracks whether the host hard-enforces the
+// `allowed-tools` frontmatter on agents (Claude Code) or leaves it advisory
+// (everyone else); we surface that at install time so users of non-Claude
+// hosts know the reviewer isolation is backed by prompt discipline, not
+// tool-restriction.
+//
+// Copilot was formerly targeted at `~/.github/skills` — wrong and dangerous
+// (collides with common GitHub dotfiles, and `gh copilot` does not read
+// that path). Removed until a real integration point exists; tracked in
+// #59.
 const CLI_TARGETS = [
-  { name: "claude",  dir: join(home, ".claude",  "skills"), agentDir: join(home, ".claude",  "agents"), commandDir: join(home, ".claude",  "commands"), platform: "claude"  },
-  { name: "gemini",  dir: join(home, ".gemini",  "skills"), agentDir: join(home, ".gemini",  "agents"), commandDir: join(home, ".gemini",  "commands"), platform: "gemini"  },
-  { name: "copilot", dir: join(home, ".github",  "skills"), agentDir: join(home, ".github",  "agents"), commandDir: join(home, ".github",  "commands"), platform: "copilot" },
-  { name: "codex",   dir: join(home, ".codex",   "skills"), agentDir: join(home, ".codex",   "agents"), commandDir: join(home, ".codex",   "commands"), platform: "codex"   },
-  { name: "cursor",  dir: join(home, ".cursor",  "skills"), agentDir: join(home, ".cursor",  "agents"), commandDir: join(home, ".cursor",  "commands"), platform: "cursor"  },
-  { name: "kiro",    dir: join(home, ".kiro",    "skills"), agentDir: join(home, ".kiro",    "agents"), commandDir: join(home, ".kiro",    "commands"), platform: "kiro"    },
+  {
+    name: "claude",
+    rootDir: join(home, ".claude"),
+    dir: join(home, ".claude", "skills"),
+    agentDir: join(home, ".claude", "agents"),
+    commandDir: join(home, ".claude", "commands"),
+    platform: "claude",
+    identityMarkers: ["settings.json", "plugins", "projects"],
+    isolationTier: "hard", // allowed-tools is host-enforced
+  },
+  {
+    name: "gemini",
+    rootDir: join(home, ".gemini"),
+    dir: join(home, ".gemini", "skills"),
+    agentDir: join(home, ".gemini", "agents"),
+    commandDir: join(home, ".gemini", "commands"),
+    platform: "gemini",
+    identityMarkers: ["config.json", "auth", "settings.json"],
+    isolationTier: "advisory",
+  },
+  {
+    name: "codex",
+    rootDir: join(home, ".codex"),
+    dir: join(home, ".codex", "skills"),
+    agentDir: join(home, ".codex", "agents"),
+    commandDir: join(home, ".codex", "commands"),
+    platform: "codex",
+    // Codex stores config in TOML and maintains a plugins/ directory; check
+    // for either plus its auth blob.
+    identityMarkers: ["config.toml", "config.json", "auth.json", "plugins"],
+    isolationTier: "advisory",
+  },
+  {
+    name: "cursor",
+    rootDir: join(home, ".cursor"),
+    dir: join(home, ".cursor", "skills"),
+    agentDir: join(home, ".cursor", "agents"),
+    commandDir: join(home, ".cursor", "commands"),
+    platform: "cursor",
+    identityMarkers: ["User", "extensions", "settings.json"],
+    isolationTier: "advisory",
+  },
+  {
+    name: "kiro",
+    rootDir: join(home, ".kiro"),
+    dir: join(home, ".kiro", "skills"),
+    agentDir: join(home, ".kiro", "agents"),
+    commandDir: join(home, ".kiro", "commands"),
+    platform: "kiro",
+    identityMarkers: ["config.json", "settings.json"],
+    isolationTier: "advisory",
+  },
 ];
+
+// A directory that exists but has none of the identity markers is treated
+// as "not really this CLI" — we skip it. Override with --assume-cli=<name>
+// if a power user knows their setup stores markers elsewhere.
+function hasIdentityMarker(target) {
+  if (!existsSync(target.rootDir)) return false;
+  for (const m of target.identityMarkers || []) {
+    if (existsSync(join(target.rootDir, m))) return true;
+  }
+  return false;
+}
 
 // --- arg parsing -----------------------------------------------------------
 
@@ -57,6 +127,7 @@ const jsonOut       = !!flagValue("json");
 const cliArg        = flagValue("cli");
 const pathArg       = flagValue("path");
 const requireSpec   = flagValue("require");
+const assumeCli     = flagValue("assume-cli");  // override identity-marker check
 
 function resolveTargets() {
   if (pathArg && typeof pathArg === "string") {
@@ -65,13 +136,27 @@ function resolveTargets() {
     const known = CLI_TARGETS.find(t => t.name === dirName);
     return [{
       name: dirName,
+      rootDir: customPath,
       dir: join(customPath, "skills"),
       agentDir: join(customPath, "agents"),
       commandDir: join(customPath, "commands"),
       platform: known?.platform ?? dirName,
+      identityMarkers: known?.identityMarkers ?? [],
+      isolationTier: known?.isolationTier ?? "advisory",
     }];
   }
-  const detected = CLI_TARGETS.filter(t => existsSync(resolve(t.dir, "..")));
+  // Identity-marker detection: presence of `~/.claude/` alone is not enough
+  // to conclude Claude Code is installed (the dir might belong to a legacy
+  // tool or another plugin). We require at least one of the per-CLI markers
+  // declared in CLI_TARGETS — `settings.json`, `plugins/`, etc. Override
+  // with --assume-cli=<name> to force-detect when the host's marker set
+  // diverges from our list.
+  const forceDetect = (assumeCli && typeof assumeCli === "string")
+    ? new Set(assumeCli.split(","))
+    : new Set();
+  const detected = CLI_TARGETS.filter(t =>
+    forceDetect.has(t.name) || hasIdentityMarker(t)
+  );
   if (cliArg && typeof cliArg === "string") {
     const filter = cliArg.split(",");
     return detected.filter(t => filter.includes(t.name));
@@ -188,8 +273,9 @@ Commands:
   help          This message
 
 Options:
-  --cli=<list>        Comma-separated CLI names (claude, gemini, copilot, codex, cursor, kiro)
+  --cli=<list>        Comma-separated CLI names (claude, gemini, codex, cursor, kiro)
   --path=<dir>        Custom target path (e.g. --path=~/.claude)
+  --assume-cli=<list> Force-detect a CLI even if its identity markers are missing
   --force             Overwrite even if versions match
   --require=<spec>    Version spec for 'check' (e.g. 0.2.0, ^0.2.0, ~0.2.1, >=0.2.0)
   --skip-self-test    Skip the SQLite bootstrap self-test (install/update only)
@@ -235,34 +321,114 @@ function cmdStatus() {
   }
 }
 
+// Each diagnostic returns { name, status: "ok"|"warn"|"fail", message, fix? }.
+// `fail` is red and exits doctor non-zero; `warn` is amber and stays green.
 async function cmdDoctor() {
-  const issues = [];
+  const checks = [];
+
+  // Node version
   const nodeVer = process.versions.node.split(".").map(Number);
-  if (nodeVer[0] < 18) issues.push(`Node ${process.versions.node} — need >= 18`);
-  const detected = CLI_TARGETS.filter(t => existsSync(resolve(t.dir, "..")));
-  if (detected.length === 0) issues.push("No AI CLIs detected in home directory");
+  checks.push(nodeVer[0] >= 18
+    ? { name: "node",          status: "ok",   message: process.versions.node }
+    : { name: "node",          status: "fail", message: `${process.versions.node} — need >= 18`, fix: "install Node 18+" });
+
+  // AI CLI detection
+  const detected = CLI_TARGETS.filter(t => hasIdentityMarker(t));
+  checks.push(detected.length > 0
+    ? { name: "cli-detection", status: "ok",   message: detected.map(d => `${d.name} (${d.isolationTier})`).join(", ") }
+    : { name: "cli-detection", status: "fail", message: "no AI CLIs detected in home directory", fix: "install Claude Code / Gemini / Codex / Cursor / Kiro, or use --path=<dir>" });
+
+  // better-sqlite3 native module
   let sqliteOk = false;
-  try { await import("better-sqlite3"); sqliteOk = true; } catch (e) { issues.push(`better-sqlite3 load failed: ${e.message}`); }
+  try { await import("better-sqlite3"); sqliteOk = true; } catch (_) { /* report below */ }
+  checks.push(sqliteOk
+    ? { name: "better-sqlite3", status: "ok",   message: "loadable" }
+    : { name: "better-sqlite3", status: "fail", message: "native module failed to load", fix: "run `npm rebuild better-sqlite3` or reinstall Node 18+ on a supported platform" });
+
+  // Per-target install-marker integrity
+  for (const t of detected) {
+    const installed = installedVersion(t);
+    if (installed === null) {
+      checks.push({ name: `install:${t.name}`, status: "warn", message: "not installed yet", fix: `run \`npx wicked-testing install --cli=${t.name}\`` });
+    } else if (installed !== VERSION) {
+      checks.push({ name: `install:${t.name}`, status: "warn", message: `installed ${installed}, code is ${VERSION}`, fix: `run \`npx wicked-testing update --cli=${t.name}\`` });
+    } else {
+      // Spot-check: a few expected agent files are present and non-empty.
+      const expected = ["wicked-testing-acceptance-test-reviewer.md", "wicked-testing-test-oracle.md"];
+      const missing = expected.filter(f => {
+        const p = join(t.agentDir, f);
+        if (!existsSync(p)) return true;
+        try { return statSync(p).size === 0; } catch { return true; }
+      });
+      checks.push(missing.length === 0
+        ? { name: `install:${t.name}`, status: "ok",   message: `${VERSION} integrity verified (${t.isolationTier})` }
+        : { name: `install:${t.name}`, status: "fail", message: `missing/empty agent files: ${missing.join(", ")}`, fix: `run \`npx wicked-testing install --force --cli=${t.name}\`` });
+    }
+  }
+
+  // Schema version vs code (HOW-IT-WORKS.md "DB newer than code")
+  const dbPath = join(process.cwd(), ".wicked-testing", "wicked-testing.db");
+  if (sqliteOk && existsSync(dbPath)) {
+    try {
+      const { default: Database } = await import("better-sqlite3");
+      const db = new Database(dbPath, { readonly: true });
+      const row = db.prepare("SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1").get();
+      db.close();
+      const dbVer = row?.version ?? 0;
+      const codeVer = 1;
+      checks.push(dbVer <= codeVer
+        ? { name: "schema",        status: "ok",   message: `DB v${dbVer}, code v${codeVer}` }
+        : { name: "schema",        status: "fail", message: `DB v${dbVer} is newer than code v${codeVer}`, fix: "upgrade wicked-testing: `npm install -g wicked-testing@latest`" });
+    } catch (err) {
+      checks.push({ name: "schema", status: "warn", message: `could not read schema_migrations: ${err.message}`, fix: "run `npx wicked-testing status` to see full project state" });
+    }
+  }
+
+  // plugin.json drift (delegates to sync-plugin-version --check when present)
+  const syncScript = join(__dirname, "scripts", "dev", "sync-plugin-version.mjs");
+  if (existsSync(syncScript)) {
+    try {
+      const { spawnSync } = await import("node:child_process");
+      const r = spawnSync(process.execPath, [syncScript, "--check", "--quiet"], { stdio: "pipe" });
+      checks.push(r.status === 0
+        ? { name: "plugin.json",   status: "ok",   message: "in sync with package.json + disk" }
+        : { name: "plugin.json",   status: "warn", message: "drift detected", fix: "run `node scripts/dev/sync-plugin-version.mjs`" });
+    } catch (err) {
+      checks.push({ name: "plugin.json", status: "warn", message: `drift check errored: ${err.message}` });
+    }
+  }
+
+  const fails = checks.filter(c => c.status === "fail");
+  const warns = checks.filter(c => c.status === "warn");
+
   if (jsonOut) {
     console.log(JSON.stringify({
       node: process.versions.node,
       detected_clis: detected.map(d => d.name),
       sqlite_ok: sqliteOk,
-      issues,
-      healthy: issues.length === 0,
+      checks,
+      healthy: fails.length === 0,
+      warnings: warns.length,
     }, null, 2));
+    if (fails.length > 0) exit(1);
     return;
   }
-  console.log(`wicked-testing ${VERSION} — doctor`);
-  console.log(`  Node:           ${process.versions.node}`);
-  console.log(`  Detected CLIs:  ${detected.map(d => d.name).join(", ") || "(none)"}`);
-  console.log(`  better-sqlite3: ${sqliteOk ? "ok" : "FAIL"}`);
-  if (issues.length) {
-    console.log("\nIssues:");
-    for (const i of issues) console.log(`  - ${i}`);
+
+  const color = (txt, c) => `\x1b[${c}m${txt}\x1b[0m`;
+  const badge = (s) => s === "ok" ? color("✓ ok  ", 32) : s === "warn" ? color("! warn", 33) : color("✗ fail", 31);
+  console.log(`wicked-testing ${VERSION} — doctor\n`);
+  for (const c of checks) {
+    console.log(`  ${badge(c.status)}  ${c.name.padEnd(22)} ${c.message}`);
+    if (c.fix && c.status !== "ok") console.log(`         ${color("→", 36)} ${c.fix}`);
+  }
+  console.log();
+  if (fails.length > 0) {
+    console.log(color(`${fails.length} failure${fails.length === 1 ? "" : "s"}, ${warns.length} warning${warns.length === 1 ? "" : "s"}`, 31));
     exit(1);
+  } else if (warns.length > 0) {
+    console.log(color(`all critical checks passed (${warns.length} warning${warns.length === 1 ? "" : "s"})`, 33));
   } else {
-    console.log("\nAll good.");
+    console.log(color("all good", 32));
   }
 }
 
@@ -270,7 +436,7 @@ async function cmdInstall({ mode }) {
   const targets = resolveTargets();
   if (targets.length === 0) {
     console.error("No AI CLIs detected. Supported: " + CLI_TARGETS.map(t => t.name).join(", "));
-    console.error("Use --path=<dir> to target a custom location.");
+    console.error("Use --path=<dir> to target a custom location, or --assume-cli=<name> to override identity-marker detection.");
     exit(1);
   }
 
@@ -285,34 +451,70 @@ async function cmdInstall({ mode }) {
   const commandFiles = readdirSafe(commandsSrc).filter(f => f.endsWith(".md"));
 
   let totalSkills = 0, totalAgents = 0, totalCommands = 0;
+  const perTargetReport = [];
 
   for (const target of targets) {
     const existing = installedVersion(target);
     if (existing === VERSION && !force && mode !== "update") {
       console.log(`[${target.name}] already at ${VERSION}, skipping (--force to overwrite)`);
+      perTargetReport.push({ target: target.name, status: "skipped", reason: "already-current", isolationTier: target.isolationTier });
       continue;
     }
 
-    mkdirSync(target.dir, { recursive: true });
-    for (const skill of skillDirs) copyTree(join(skillsSrc, skill), join(target.dir, `wicked-testing-${skill}`));
-    totalSkills += skillDirs.length;
-
-    if (target.agentDir) {
-      mkdirSync(target.agentDir, { recursive: true });
-      for (const f of agentFiles) cpSync(join(agentsSrc, f), join(target.agentDir, `wicked-testing-${f}`), { force: true });
-      for (const f of specialistFiles) cpSync(join(specialistsSrc, f), join(target.agentDir, `wicked-testing-${f}`), { force: true });
-      totalAgents += agentFiles.length + specialistFiles.length;
+    // Writable-path pre-flight. If the home-slice is locked (corporate Mac
+    // with SIP, Windows profile sealed by policy, NFS-mounted read-only
+    // home), fail the target cleanly with an actionable line instead of
+    // a raw Node stack that leaves the user wondering which target broke.
+    // Other targets in the loop still run.
+    try {
+      mkdirSync(target.dir, { recursive: true });
+      accessSync(target.dir, FS_CONST.W_OK);
+    } catch (err) {
+      const code = err?.code || "EUNKNOWN";
+      console.error(`[${target.name}] SKIPPED — cannot write to ${target.dir}: ${code}`);
+      perTargetReport.push({ target: target.name, status: "skipped", reason: code, isolationTier: target.isolationTier });
+      continue;
     }
 
-    if (target.commandDir) {
-      const cmdDir = join(target.commandDir, "wicked-testing");
-      mkdirSync(cmdDir, { recursive: true });
-      for (const f of commandFiles) cpSync(join(commandsSrc, f), join(cmdDir, f), { force: true });
-      totalCommands += commandFiles.length;
-    }
+    try {
+      for (const skill of skillDirs) copyTree(join(skillsSrc, skill), join(target.dir, `wicked-testing-${skill}`));
+      totalSkills += skillDirs.length;
 
-    writeMarker(target);
-    console.log(`[${target.name}] installed ${VERSION} (skills=${skillDirs.length} agents=${agentFiles.length}+${specialistFiles.length} commands=${commandFiles.length})`);
+      if (target.agentDir) {
+        mkdirSync(target.agentDir, { recursive: true });
+        for (const f of agentFiles) cpSync(join(agentsSrc, f), join(target.agentDir, `wicked-testing-${f}`), { force: true });
+        for (const f of specialistFiles) cpSync(join(specialistsSrc, f), join(target.agentDir, `wicked-testing-${f}`), { force: true });
+        totalAgents += agentFiles.length + specialistFiles.length;
+      }
+
+      if (target.commandDir) {
+        const cmdDir = join(target.commandDir, "wicked-testing");
+        mkdirSync(cmdDir, { recursive: true });
+        for (const f of commandFiles) cpSync(join(commandsSrc, f), join(cmdDir, f), { force: true });
+        totalCommands += commandFiles.length;
+      }
+
+      writeMarker(target);
+      console.log(`[${target.name}] installed ${VERSION} (skills=${skillDirs.length} agents=${agentFiles.length}+${specialistFiles.length} commands=${commandFiles.length})`);
+
+      // Surface the isolation tier so users of non-Claude hosts know the
+      // reviewer's `allowed-tools: [Read]` is prompt-enforced, not
+      // host-enforced. See #73 / docs/INTEGRATION.md.
+      if (target.isolationTier === "advisory") {
+        console.log(`[${target.name}] note: allowed-tools isolation is ADVISORY on this CLI (prompt-enforced, not host-enforced). For hard isolation use Claude Code.`);
+      }
+
+      perTargetReport.push({
+        target: target.name,
+        status: "installed",
+        version: VERSION,
+        isolationTier: target.isolationTier,
+      });
+    } catch (err) {
+      const code = err?.code || "EUNKNOWN";
+      console.error(`[${target.name}] SKIPPED mid-install — ${code}: ${err?.message ?? err}`);
+      perTargetReport.push({ target: target.name, status: "failed", reason: code, isolationTier: target.isolationTier });
+    }
   }
 
   if (!skipSelfTest && mode !== "update") {
@@ -325,8 +527,19 @@ async function cmdInstall({ mode }) {
   }
 
   if (jsonOut) {
-    console.log(JSON.stringify({ version: VERSION, targets: targets.map(t => t.name), skills: totalSkills, agents: totalAgents, commands: totalCommands }));
+    console.log(JSON.stringify({
+      version: VERSION,
+      targets: perTargetReport,
+      skills: totalSkills,
+      agents: totalAgents,
+      commands: totalCommands,
+    }));
   }
+
+  // Non-zero exit if any target skipped due to a real failure (not just
+  // "already installed"). This matches CI expectations — an install script
+  // that partially succeeded should be a non-green build.
+  if (perTargetReport.some(r => r.status === "failed")) exit(1);
 }
 
 function cmdUninstall() {

--- a/lib/exec-with-timeout.mjs
+++ b/lib/exec-with-timeout.mjs
@@ -68,9 +68,19 @@ export function execWithTimeout(opts) {
 
   if (!command) throw new Error("execWithTimeout: `command` is required");
 
+  // Three supported call shapes:
+  //   1. { command: "echo hello" }                          — shell-string
+  //   2. { command: "node", args: ["-e", "..."] }           — argv (opts.args)
+  //   3. { command: ["node", "-e", "..."] }                 — argv (array)
+  // When `command` is an array we split it into exe + args and run without
+  // a shell (same safety posture as (2)). The previous implementation
+  // advertised shape #3 in the JSDoc but spawn()'d the whole array as the
+  // executable path, which failed.
   const useShell = typeof command === "string" && !Array.isArray(args);
-  const spawnCmd = useShell ? command : command;
-  const spawnArgs = useShell ? [] : (args || []);
+  const spawnCmd = Array.isArray(command) ? command[0] : command;
+  const spawnArgs = Array.isArray(command)
+    ? command.slice(1)
+    : (useShell ? [] : (args || []));
 
   return new Promise((resolve, reject) => {
     const started = Date.now();

--- a/lib/exec-with-timeout.mjs
+++ b/lib/exec-with-timeout.mjs
@@ -1,0 +1,168 @@
+/**
+ * lib/exec-with-timeout.mjs — Node-enforced step timeout.
+ *
+ * Replaces the previous "shell out to `timeout ${N}`" pattern that assumed
+ * GNU coreutils. Stock macOS ships BSD userland with no `/usr/bin/timeout`;
+ * Windows Git Bash depends on the MSYS2 package set. On either host the
+ * scenario's `timeout` frontmatter field used to silently fail to enforce.
+ *
+ * This wrapper spawns the command, arms an AbortController-driven kill
+ * timer, and returns a structured result (stdout, stderr, exitCode, timed
+ * out yes/no, wall-clock ms). Everything runs through Node, so portability
+ * is the same as Node itself — macOS, Linux, Windows all equivalent.
+ *
+ * Skills/agents that used to write:
+ *
+ *     timeout ${TIMEOUT:-120} bash -c '{step_command}'
+ *
+ * should now invoke the caller via Node (directly or through the dev
+ * `scripts/_python.sh` shim if Node isn't available), or emit a shell
+ * fallback chain `timeout || gtimeout || bare` with a loud log noting
+ * enforcement is disabled.
+ */
+
+import { spawn } from "node:child_process";
+
+/**
+ * Default timeout for scenario steps (2 minutes) — matches SCENARIO-FORMAT.md.
+ */
+export const DEFAULT_TIMEOUT_MS = 120_000;
+
+/**
+ * Execute a single command with a hard Node-side kill timer.
+ *
+ * @param {object} opts
+ * @param {string|string[]} opts.command  Shell string (run via shell:true)
+ *   OR argv array (run directly, safer — no shell expansion).
+ * @param {string[]} [opts.args]          argv when `command` is an executable
+ *   path and `args` is the parameter list. Mutually exclusive with using
+ *   `command` as a shell string.
+ * @param {number} [opts.timeoutMs]       Max wall-clock ms before kill.
+ *   Defaults to DEFAULT_TIMEOUT_MS. Pass 0 or Infinity to disable.
+ * @param {string} [opts.cwd]             Working directory. Defaults to
+ *   process.cwd().
+ * @param {object} [opts.env]             Environment overrides.
+ * @param {string} [opts.stdin]           Optional stdin text to feed the child.
+ * @param {string} [opts.killSignal]      Signal to send on timeout.
+ *   Defaults to "SIGKILL" (SIGTERM is often ignored by stuck scripts).
+ * @returns {Promise<{
+ *   stdout: string,
+ *   stderr: string,
+ *   exitCode: number|null,
+ *   signal: string|null,
+ *   timedOut: boolean,
+ *   durationMs: number,
+ *   command: string,
+ * }>}
+ */
+export function execWithTimeout(opts) {
+  const {
+    command,
+    args,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    cwd,
+    env,
+    stdin,
+    killSignal = "SIGKILL",
+  } = opts;
+
+  if (!command) throw new Error("execWithTimeout: `command` is required");
+
+  const useShell = typeof command === "string" && !Array.isArray(args);
+  const spawnCmd = useShell ? command : command;
+  const spawnArgs = useShell ? [] : (args || []);
+
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    let stdout = "";
+    let stderr = "";
+    let killed = false;
+    let timer = null;
+
+    let child;
+    try {
+      child = spawn(spawnCmd, spawnArgs, {
+        cwd,
+        env: env ? { ...process.env, ...env } : process.env,
+        shell: useShell,
+        stdio: stdin != null ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
+      });
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    if (stdin != null && child.stdin) {
+      child.stdin.end(stdin);
+    }
+
+    if (timeoutMs && timeoutMs !== Infinity && timeoutMs > 0) {
+      timer = setTimeout(() => {
+        killed = true;
+        try { child.kill(killSignal); } catch { /* already exited */ }
+      }, timeoutMs);
+    }
+
+    child.stdout?.on("data", (chunk) => { stdout += chunk.toString("utf8"); });
+    child.stderr?.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
+
+    child.on("error", (err) => {
+      if (timer) clearTimeout(timer);
+      // ENOENT etc. — the command wasn't spawnable at all. Report as a
+      // structured failure so callers see the same shape regardless.
+      resolve({
+        stdout,
+        stderr: stderr + (stderr && !stderr.endsWith("\n") ? "\n" : "") + String(err?.message ?? err),
+        exitCode: null,
+        signal: null,
+        timedOut: false,
+        durationMs: Date.now() - started,
+        command: renderCommand(spawnCmd, spawnArgs),
+      });
+    });
+
+    child.on("close", (exitCode, signal) => {
+      if (timer) clearTimeout(timer);
+      resolve({
+        stdout,
+        stderr,
+        exitCode: exitCode ?? null,
+        signal: signal ?? null,
+        timedOut: killed,
+        durationMs: Date.now() - started,
+        command: renderCommand(spawnCmd, spawnArgs),
+      });
+    });
+  });
+}
+
+function renderCommand(cmd, args) {
+  if (!args || args.length === 0) return String(cmd);
+  return [cmd, ...args].map(a => /\s/.test(String(a)) ? `"${a}"` : String(a)).join(" ");
+}
+
+/**
+ * Convenience: execute and return a shaped result that looks like the
+ * existing evidence step record. Skills/agents that used to write:
+ *
+ *     {
+ *       "stdout": "...",
+ *       "stderr": "...",
+ *       "exit_code": 0
+ *     }
+ *
+ * can build that shape directly from this wrapper's output.
+ *
+ * @returns {Promise<{stdout: string, stderr: string, exit_code: number|null, timed_out: boolean, duration_ms: number}>}
+ */
+export async function runStep(opts) {
+  const r = await execWithTimeout(opts);
+  return {
+    stdout: r.stdout,
+    stderr: r.stderr,
+    exit_code: r.exitCode,
+    timed_out: r.timedOut,
+    duration_ms: r.durationMs,
+    command: r.command,
+  };
+}

--- a/scenarios/examples/a11y-wcag-check.md
+++ b/scenarios/examples/a11y-wcag-check.md
@@ -27,7 +27,7 @@ if ! command -v pa11y &>/dev/null; then
   echo "SKIP: pa11y not installed. Run /wicked-testing:setup to install."
   exit 0
 fi
-pa11y --standard WCAG2AA --reporter json "${PAGE_URL}" > "${TMPDIR:-/tmp}/pa11y-results.json" 2>&1
+pa11y --standard WCAG2AA --reporter json "${PAGE_URL}" > "${TMPDIR:-${TEMP:-/tmp}}/pa11y-results.json" 2>&1
 ```
 
 **Expect**: Exit code 0 if no accessibility issues, exit code 2 if issues found
@@ -47,5 +47,5 @@ pa11y --standard WCAG2AA "${PAGE_URL}" 2>&1 | head -20
 ## Cleanup
 
 ```bash
-rm -f "${TMPDIR:-/tmp}/pa11y-results.json"
+rm -f "${TMPDIR:-${TEMP:-/tmp}}/pa11y-results.json"
 ```

--- a/scenarios/examples/api-health-check.md
+++ b/scenarios/examples/api-health-check.md
@@ -45,14 +45,14 @@ if ! command -v hurl &>/dev/null; then
   echo "SKIP: hurl not installed. Run /wicked-testing:setup to install."
   exit 0
 fi
-cat > "${TMPDIR:-/tmp}/wicked-scenario-hurl.hurl" << 'HURL_EOF'
+cat > "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-hurl.hurl" << 'HURL_EOF'
 GET https://httpbin.org/get
 HTTP 200
 [Asserts]
 header "Content-Type" contains "application/json"
 jsonpath "$.url" == "https://httpbin.org/get"
 HURL_EOF
-hurl --test "${TMPDIR:-/tmp}/wicked-scenario-hurl.hurl"
+hurl --test "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-hurl.hurl"
 ```
 
 **Expect**: All hurl assertions pass
@@ -60,5 +60,5 @@ hurl --test "${TMPDIR:-/tmp}/wicked-scenario-hurl.hurl"
 ## Cleanup
 
 ```bash
-rm -f "${TMPDIR:-/tmp}/wicked-scenario-hurl.hurl"
+rm -f "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-hurl.hurl"
 ```

--- a/scenarios/examples/browser-page-audit.md
+++ b/scenarios/examples/browser-page-audit.md
@@ -16,10 +16,10 @@ Verifies that a web page loads successfully, renders expected content, and respo
 ## Setup
 
 ```bash
-mkdir -p "${TMPDIR:-/tmp}/wicked-scenario-pw"
+mkdir -p "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw"
 
 # Create a local HTML fixture for deterministic testing
-cat > "${TMPDIR:-/tmp}/wicked-scenario-pw/index.html" << 'HTML_EOF'
+cat > "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw/index.html" << 'HTML_EOF'
 <!DOCTYPE html>
 <html lang="en">
 <head><meta charset="utf-8"><title>Wicked Test Page</title></head>
@@ -34,12 +34,12 @@ HTML_EOF
 
 # Pick a free port (fall back to 8765 if python one-liner fails)
 SCEN_PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()" 2>/dev/null || echo 8765)
-echo "$SCEN_PORT" > "${TMPDIR:-/tmp}/wicked-scenario-pw/port"
+echo "$SCEN_PORT" > "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw/port"
 
 # Start a local server in the background
-python3 -m http.server "$SCEN_PORT" --directory "${TMPDIR:-/tmp}/wicked-scenario-pw" &
+python3 -m http.server "$SCEN_PORT" --directory "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw" &
 SERVER_PID=$!
-echo "$SERVER_PID" > "${TMPDIR:-/tmp}/wicked-scenario-pw/server.pid"
+echo "$SERVER_PID" > "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw/server.pid"
 
 # Wait for the server to be ready (up to 5 seconds)
 for i in 1 2 3 4 5; do
@@ -57,7 +57,7 @@ if ! command -v agent-browser &>/dev/null; then
   echo "SKIP: agent-browser not installed — skipping step 1"
   exit 0
 fi
-SCEN_PORT=$(cat "${TMPDIR:-/tmp}/wicked-scenario-pw/port")
+SCEN_PORT=$(cat "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw/port")
 agent-browser open "http://localhost:${SCEN_PORT}/" --headless
 SNAPSHOT=$(agent-browser snapshot)
 echo "$SNAPSHOT"
@@ -86,14 +86,14 @@ echo "PASS: all expected content present in DOM"
 ### Step 3: Screenshot capture
 
 ```bash
-SCEN_PORT=$(cat "${TMPDIR:-/tmp}/wicked-scenario-pw/port")
+SCEN_PORT=$(cat "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw/port")
 if command -v playwright &>/dev/null; then
-  playwright screenshot "http://localhost:${SCEN_PORT}/" "${TMPDIR:-/tmp}/wicked-scenario-pw/screenshot.png" 2>&1
-  [ -f "${TMPDIR:-/tmp}/wicked-scenario-pw/screenshot.png" ] || { echo "FAIL: screenshot not created"; exit 1; }
+  playwright screenshot "http://localhost:${SCEN_PORT}/" "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw/screenshot.png" 2>&1
+  [ -f "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw/screenshot.png" ] || { echo "FAIL: screenshot not created"; exit 1; }
   echo "PASS: screenshot captured via playwright CLI"
 elif command -v agent-browser &>/dev/null; then
-  agent-browser screenshot "${TMPDIR:-/tmp}/wicked-scenario-pw/screenshot.png" 2>&1
-  [ -f "${TMPDIR:-/tmp}/wicked-scenario-pw/screenshot.png" ] || { echo "FAIL: screenshot not created"; exit 1; }
+  agent-browser screenshot "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw/screenshot.png" 2>&1
+  [ -f "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw/screenshot.png" ] || { echo "FAIL: screenshot not created"; exit 1; }
   echo "PASS: screenshot captured via agent-browser"
 else
   echo "SKIP: neither playwright nor agent-browser installed — skipping step 3"
@@ -122,8 +122,8 @@ echo "PASS: link click navigated to about section"
 
 ```bash
 # Stop the local server
-if [ -f "${TMPDIR:-/tmp}/wicked-scenario-pw/server.pid" ]; then
-  kill "$(cat "${TMPDIR:-/tmp}/wicked-scenario-pw/server.pid")" 2>/dev/null || true
+if [ -f "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw/server.pid" ]; then
+  kill "$(cat "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw/server.pid")" 2>/dev/null || true
 fi
-rm -rf "${TMPDIR:-/tmp}/wicked-scenario-pw"
+rm -rf "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-pw"
 ```

--- a/scenarios/examples/infra-container-scan.md
+++ b/scenarios/examples/infra-container-scan.md
@@ -28,7 +28,7 @@ if ! command -v trivy &>/dev/null; then
   echo "SKIP: trivy not installed. Run /wicked-testing:setup to install."
   exit 0
 fi
-trivy image --severity HIGH,CRITICAL --exit-code 0 --format json --output "${TMPDIR:-/tmp}/trivy-results.json" "${IMAGE}" && echo "Scan complete"
+trivy image --severity HIGH,CRITICAL --exit-code 0 --format json --output "${TMPDIR:-${TEMP:-/tmp}}/trivy-results.json" "${IMAGE}" && echo "Scan complete"
 ```
 
 **Expect**: Exit code 0, scan completes with JSON results
@@ -48,5 +48,5 @@ trivy image --severity CRITICAL --exit-code 1 "${IMAGE}"
 ## Cleanup
 
 ```bash
-rm -f "${TMPDIR:-/tmp}/trivy-results.json"
+rm -f "${TMPDIR:-${TEMP:-/tmp}}/trivy-results.json"
 ```

--- a/scenarios/examples/perf-load-test.md
+++ b/scenarios/examples/perf-load-test.md
@@ -27,7 +27,7 @@ if ! command -v hey &>/dev/null; then
   echo "SKIP: hey not installed. Run /wicked-testing:setup to install."
   exit 0
 fi
-hey -n 100 -c 10 -t 10 "${TARGET_URL}" 2>&1 | tee "${TMPDIR:-/tmp}/hey-results.txt" && grep -q "Status code distribution" "${TMPDIR:-/tmp}/hey-results.txt"
+hey -n 100 -c 10 -t 10 "${TARGET_URL}" 2>&1 | tee "${TMPDIR:-${TEMP:-/tmp}}/hey-results.txt" && grep -q "Status code distribution" "${TMPDIR:-${TEMP:-/tmp}}/hey-results.txt"
 ```
 
 **Expect**: Exit code 0, 100 requests complete with status code distribution shown
@@ -39,7 +39,7 @@ if ! command -v k6 &>/dev/null; then
   echo "SKIP: k6 not installed. Run /wicked-testing:setup to install."
   exit 0
 fi
-cat > "${TMPDIR:-/tmp}/wicked-scenario-k6.js" << 'K6_EOF'
+cat > "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-k6.js" << 'K6_EOF'
 import http from 'k6/http';
 import { check } from 'k6';
 
@@ -57,7 +57,7 @@ export default function () {
   check(res, { 'status is 200': (r) => r.status === 200 });
 }
 K6_EOF
-k6 run "${TMPDIR:-/tmp}/wicked-scenario-k6.js"
+k6 run "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-k6.js"
 ```
 
 **Expect**: Exit code 0 if thresholds met, non-zero if p95 > 2s or error rate > 10%
@@ -65,5 +65,5 @@ k6 run "${TMPDIR:-/tmp}/wicked-scenario-k6.js"
 ## Cleanup
 
 ```bash
-rm -f "${TMPDIR:-/tmp}/hey-results.txt" "${TMPDIR:-/tmp}/wicked-scenario-k6.js"
+rm -f "${TMPDIR:-${TEMP:-/tmp}}/hey-results.txt" "${TMPDIR:-${TEMP:-/tmp}}/wicked-scenario-k6.js"
 ```

--- a/scenarios/examples/security-sast-scan.md
+++ b/scenarios/examples/security-sast-scan.md
@@ -28,7 +28,7 @@ if ! command -v semgrep &>/dev/null; then
   echo "SKIP: semgrep not installed. Run /wicked-testing:setup to install."
   exit 0
 fi
-semgrep scan --config p/owasp-top-ten --json --quiet "${SCAN_TARGET}" > "${TMPDIR:-/tmp}/semgrep-results.json" 2>&1
+semgrep scan --config p/owasp-top-ten --json --quiet "${SCAN_TARGET}" > "${TMPDIR:-${TEMP:-/tmp}}/semgrep-results.json" 2>&1
 ```
 
 **Expect**: Exit code 0 = no findings, exit code 1 = findings found (treated as FAIL — security issues detected)
@@ -58,5 +58,5 @@ sys.exit(1 if len(high) > 10 else 0)
 ## Cleanup
 
 ```bash
-rm -f "${TMPDIR:-/tmp}/semgrep-results.json"
+rm -f "${TMPDIR:-${TEMP:-/tmp}}/semgrep-results.json"
 ```

--- a/scripts/dev/sync-plugin-version.mjs
+++ b/scripts/dev/sync-plugin-version.mjs
@@ -1,13 +1,20 @@
 #!/usr/bin/env node
-// Keeps .claude-plugin/plugin.json#version in lockstep with package.json#version.
-// Invoked by the `prepublishOnly` script so npm publish never ships a drifted
-// plugin manifest.
+// Keeps .claude-plugin/plugin.json in lockstep with package.json AND with
+// the actual skills/agents/commands on disk. Invoked by `prepublishOnly` so
+// npm publish never ships a drifted plugin manifest; `--check` mode is
+// called by `npm test` to catch drift at PR time before it reaches a
+// release.
 //
-// Exits 0 on success (including no-op). Exits 1 if the files cannot be read,
-// parsed, or written. Use `--check` to fail instead of writing when drift is
-// detected (useful in CI to assert the manifest is already in sync).
+// Kept under the historical name `sync-plugin-version.mjs` to avoid
+// breaking the package.json script references; scope expanded from
+// version-only (Wave 1) to the full manifest in Wave 5 (#67).
+//
+// Exit codes:
+//   0 — manifest is in sync (or was successfully synced when not --check)
+//   1 — drift detected and --check was passed, or write failed
+//   2 — inputs could not be read / parsed
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -16,25 +23,102 @@ const REPO = resolve(__dirname, "..", "..");
 
 const pkgPath    = join(REPO, "package.json");
 const pluginPath = join(REPO, ".claude-plugin", "plugin.json");
-const checkOnly  = process.argv.includes("--check");
+const argv = process.argv.slice(2);
+const checkOnly = argv.includes("--check");
+const quiet     = argv.includes("--quiet");
 
-const pkg    = JSON.parse(readFileSync(pkgPath, "utf8"));
-const plugin = JSON.parse(readFileSync(pluginPath, "utf8"));
+function log(...parts) { if (!quiet) console.log(...parts); }
 
-if (plugin.version === pkg.version) {
-  if (!process.argv.includes("--quiet")) {
-    console.log(`plugin.json version in sync (${pkg.version})`);
-  }
+let pkg, plugin;
+try {
+  pkg    = JSON.parse(readFileSync(pkgPath, "utf8"));
+  plugin = JSON.parse(readFileSync(pluginPath, "utf8"));
+} catch (err) {
+  console.error(`sync-plugin-version: could not read inputs — ${err.message}`);
+  process.exit(2);
+}
+
+// --- Derive the canonical manifest shape from disk -------------------------
+
+function listSkills() {
+  const dir = join(REPO, "skills");
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter(d => {
+      try { return statSync(join(dir, d)).isDirectory() && existsSync(join(dir, d, "SKILL.md")); }
+      catch { return false; }
+    })
+    .sort()
+    .map(d => ({
+      name:    `wicked-testing:${d}`,
+      path:    `skills/${d}/SKILL.md`,
+      command: `/wicked-testing:${d}`,
+    }));
+}
+
+function listAgents() {
+  const dir = join(REPO, "agents");
+  if (!existsSync(dir)) return [];
+  const direct = readdirSync(dir)
+    .filter(f => f.endsWith(".md"))
+    .sort()
+    .map(f => ({ name: f.replace(/\.md$/, ""), path: `agents/${f}` }));
+  const specDir = join(dir, "specialists");
+  const specialists = existsSync(specDir)
+    ? readdirSync(specDir)
+        .filter(f => f.endsWith(".md"))
+        .sort()
+        .map(f => ({ name: f.replace(/\.md$/, ""), path: `agents/specialists/${f}` }))
+    : [];
+  return [...direct, ...specialists];
+}
+
+function listCommands() {
+  const dir = join(REPO, "commands");
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter(f => f.endsWith(".md"))
+    .sort()
+    .map(f => {
+      const name = f.replace(/\.md$/, "");
+      return { name, path: `commands/${f}`, slash: `/wicked-testing:${name}` };
+    });
+}
+
+const desired = {
+  version:     pkg.version,
+  skills:      listSkills(),
+  agents:      listAgents(),
+  commands:    listCommands(),
+};
+
+// --- Diff each section against the current manifest ------------------------
+
+function jsonEqual(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+const drifts = [];
+if (plugin.version !== desired.version)       drifts.push(`version: ${plugin.version} -> ${desired.version}`);
+if (!jsonEqual(plugin.skills,   desired.skills))   drifts.push(`skills (${plugin.skills?.length ?? 0} -> ${desired.skills.length})`);
+if (!jsonEqual(plugin.agents,   desired.agents))   drifts.push(`agents (${plugin.agents?.length ?? 0} -> ${desired.agents.length})`);
+if (!jsonEqual(plugin.commands, desired.commands)) drifts.push(`commands (${plugin.commands?.length ?? 0} -> ${desired.commands.length})`);
+
+if (drifts.length === 0) {
+  log(`plugin.json in sync (v${pkg.version}, ${desired.skills.length} skills, ${desired.agents.length} agents, ${desired.commands.length} commands)`);
   process.exit(0);
 }
 
 if (checkOnly) {
-  console.error(`plugin.json version drift: plugin.json=${plugin.version} package.json=${pkg.version}`);
+  console.error(`plugin.json drift detected:`);
+  for (const d of drifts) console.error(`  - ${d}`);
   console.error(`run: node scripts/dev/sync-plugin-version.mjs`);
   process.exit(1);
 }
 
-const prev = plugin.version;
-plugin.version = pkg.version;
-writeFileSync(pluginPath, JSON.stringify(plugin, null, 2) + "\n");
-console.log(`plugin.json version ${prev} -> ${pkg.version}`);
+// --- Apply changes ---------------------------------------------------------
+
+const merged = { ...plugin, ...desired };
+writeFileSync(pluginPath, JSON.stringify(merged, null, 2) + "\n");
+log(`plugin.json updated:`);
+for (const d of drifts) log(`  - ${d}`);

--- a/scripts/dev/validate.mjs
+++ b/scripts/dev/validate.mjs
@@ -166,6 +166,166 @@ function checkEvidenceSchema() {
   if (!data.required) err("schema", rel, "missing required fields array");
 }
 
+// --- cross-platform shell portability gate ---------------------------------
+// Scans fenced bash blocks in agents/, skills/, commands/, scenarios/, and
+// top-level scenario/format docs for Unix-only shell constructs that violate
+// the global CLAUDE.md portability rule (must work on macOS/Linux AND Windows
+// Git Bash / PowerShell). Each finding lands as `warn` so `npm test` doesn't
+// regress while the audit lands — flip to `err` once the tree is clean
+// across all audit branches.
+function checkCrossPlatform() {
+  const scanPaths = [
+    { dir: join(REPO, "agents"),        glob: /\.md$/ },
+    { dir: join(REPO, "agents", "specialists"), glob: /\.md$/ },
+    { dir: join(REPO, "commands"),      glob: /\.md$/ },
+    { dir: join(REPO, "skills"),        glob: /SKILL\.md$/, recursive: true },
+    { dir: join(REPO, "scenarios"),     glob: /\.md$/, recursive: true },
+  ];
+  const topLevelFiles = ["SCENARIO-FORMAT.md"];
+
+  const files = [];
+  for (const { dir, glob, recursive } of scanPaths) {
+    if (!existsSync(dir)) continue;
+    walkMarkdown(dir, glob, !!recursive, files);
+  }
+  for (const f of topLevelFiles) {
+    const p = join(REPO, f);
+    if (existsSync(p)) files.push(p);
+  }
+
+  // Patterns that indicate a Unix-only construct. Each matcher runs against
+  // the *shell-block text only* (we skip prose so mentions inside backticks
+  // or documentation don't fire false positives). Each matcher returns an
+  // array of { line, message } tuples.
+  const shellMatchers = [
+    {
+      name: "printf-newline-literal",
+      // printf 'foo\n' — zsh vs bash expand \n differently. Use '%s\n' or Python.
+      test: (line) => /\bprintf\s+['"][^'"%]*\\n/.test(line),
+      message: "printf with literal \\n but no %s — zsh/bash differ. Use `printf '%s\\n' ...` or a Python one-liner.",
+    },
+    {
+      name: "echo-e",
+      test: (line) => /\becho\s+-e\b/.test(line),
+      message: "`echo -e` is not portable (bash built-in behavior varies). Use `printf '%s\\n' ...` or Python.",
+    },
+    {
+      name: "bare-tmp",
+      // /tmp/... that is NOT inside a ${TMPDIR:-...} fallback on the same line.
+      test: (line) => {
+        if (!/\s\/tmp\//.test(line) && !/^"?\/tmp\//.test(line)) return false;
+        if (/\$\{TMPDIR:-/.test(line)) return false;       // guarded
+        if (/\$\{TEMP:-/.test(line))   return false;       // guarded
+        if (/^#/.test(line.trimStart())) return false;     // comment
+        return true;
+      },
+      message: "Bare `/tmp/...` path — use `${TMPDIR:-${TEMP:-/tmp}}` (Windows uses TEMP, not TMPDIR).",
+    },
+    {
+      name: "unguarded-stderr-null",
+      // 2>/dev/null that is NOT followed by `||` within ~20 chars on the same
+      // line. Multi-line chains are OK because the Python fallback lives on
+      // the next line, so we also pass if the line ends with `\` (continuation).
+      test: (line) => {
+        const m = line.match(/2>\/dev\/null(.*)$/);
+        if (!m) return false;
+        const tail = m[1];
+        if (/^\s*\\\s*$/.test(tail)) return false;         // line continuation
+        if (/\|\|/.test(tail))        return false;        // guarded with ||
+        if (/\|\s*\w/.test(tail))     return false;        // piped into next cmd (not a bare swallow)
+        return true;
+      },
+      message: "`2>/dev/null` not followed by `||` fallback on same line — add `|| true` / `|| python -c ...` or drop the redirect.",
+    },
+    {
+      name: "bare-timeout",
+      // `timeout` as the first word of a command, not inside a `command -v`
+      // guard. GNU timeout is absent from stock macOS and Windows Git Bash.
+      test: (line) => {
+        const trimmed = line.trimStart();
+        if (!/^timeout\s+\S/.test(trimmed)) return false;
+        // already wrapped in an if-guard elsewhere; the detector only fires
+        // on a raw pipeline start.
+        return true;
+      },
+      message: "Bare `timeout ...` pipeline — not present on stock macOS / Windows Git Bash. Chain `if command -v timeout ... elif gtimeout ... else bare`, or use `lib/exec-with-timeout.mjs`.",
+    },
+    {
+      name: "sed-i-no-backup",
+      // `sed -i` with no backup suffix — GNU vs BSD syntax differs.
+      test: (line) => /\bsed\s+-i\s+(?!['"][^'"]*['"]\s)/.test(line) && !/sed\s+-i\s+\.\w+/.test(line) && !/sed\s+-i\s+''/.test(line),
+      message: "`sed -i` without a backup suffix — GNU and BSD syntax differ. Use `sed -i.bak ...` and delete the backup, or a Python/Node rewrite.",
+    },
+    {
+      name: "realpath-or-readlink-f",
+      test: (line) => /\brealpath\b/.test(line) || /\breadlink\s+-f\b/.test(line),
+      message: "`realpath` / `readlink -f` are GNU coreutils only. Use a Python/Node one-liner (`python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))'`).",
+    },
+    {
+      name: "find-dash-name",
+      // `find . -name ...` — portable `find` differs across BSD/GNU and is
+      // absent from Windows Git Bash's lean tool set. Prefer pathlib.rglob.
+      test: (line) => /\bfind\s+\.\s+-name\s+/.test(line) || /\bfind\s+\.\s+-type\s/.test(line),
+      message: "`find . -name` — flag set differs across BSD/GNU and is sparse on Windows. Use `python3 -c 'import pathlib; ...'` instead.",
+    },
+    {
+      name: "ls-pipe-wc",
+      test: (line) => /\bls\s.*\|\s*wc\b/.test(line),
+      message: "`ls ... | wc -l` — Windows Git Bash lacks `wc`. Use `python3 -c 'import pathlib; print(len(list(...)))'`.",
+    },
+  ];
+
+  for (const file of files) {
+    const rel = relative(REPO, file);
+    const content = readFileSync(file, "utf8");
+    // Walk fenced bash/sh/shell blocks only
+    const fenceRe = /```(bash|sh|shell|zsh)\r?\n([\s\S]*?)\r?\n```/g;
+    let m;
+    while ((m = fenceRe.exec(content)) !== null) {
+      const block = m[2];
+      const blockStart = content.slice(0, m.index).split(/\r?\n/).length + 1;
+      const blockLines = block.split(/\r?\n/);
+
+      // Track whether we're currently inside an `if command -v timeout` / gtimeout
+      // guard. The bare-timeout matcher is suppressed until the matching `fi`.
+      let timeoutGuardDepth = 0;
+      for (let i = 0; i < blockLines.length; i++) {
+        const line = blockLines[i];
+        if (!line.trim() || line.trim().startsWith("#")) continue;
+        if (/^\s*if\s+command\s+-v\s+(timeout|gtimeout)\b/.test(line)) timeoutGuardDepth++;
+        if (timeoutGuardDepth > 0 && /^\s*fi\b/.test(line)) timeoutGuardDepth--;
+
+        for (const matcher of shellMatchers) {
+          if (matcher.name === "bare-timeout" && timeoutGuardDepth > 0) continue;
+          try {
+            if (matcher.test(line)) {
+              warn("cross-platform", rel, `line ~${blockStart + i}: ${matcher.message}`);
+            }
+          } catch {
+            // Defensive: never let a bad regex break the whole validator.
+          }
+        }
+      }
+    }
+  }
+}
+
+function walkMarkdown(dir, globRe, recursive, out) {
+  let entries;
+  try { entries = readdirSync(dir); } catch { return; }
+  for (const name of entries) {
+    if (name === "node_modules" || name === ".git" || name === "workspace") continue;
+    const full = join(dir, name);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) {
+      if (recursive) walkMarkdown(full, globRe, recursive, out);
+    } else if (globRe.test(name)) {
+      out.push(full);
+    }
+  }
+}
+
 function checkNamespaceAlignment() {
   const docPath = join(REPO, "docs", "NAMESPACE.md");
   const rel = relative(REPO, docPath);
@@ -191,6 +351,7 @@ checkSkills();
 checkPluginJson();
 checkEvidenceSchema();
 checkNamespaceAlignment();
+checkCrossPlatform();
 
 const errors = findings.filter(f => f.severity === "error");
 const warns  = findings.filter(f => f.severity === "warn");

--- a/scripts/dev/validate.mjs
+++ b/scripts/dev/validate.mjs
@@ -279,7 +279,9 @@ function checkCrossPlatform() {
     const rel = relative(REPO, file);
     const content = readFileSync(file, "utf8");
     // Walk fenced bash/sh/shell blocks only
-    const fenceRe = /```(bash|sh|shell|zsh)\r?\n([\s\S]*?)\r?\n```/g;
+    // Allow trailing whitespace after the language identifier — CommonMark
+    // permits it and most editors emit it when auto-formatting.
+    const fenceRe = /```(bash|sh|shell|zsh)[ \t]*\r?\n([\s\S]*?)\r?\n```/g;
     let m;
     while ((m = fenceRe.exec(content)) !== null) {
       const block = m[2];

--- a/skills/test-runner/SKILL.md
+++ b/skills/test-runner/SKILL.md
@@ -89,8 +89,18 @@ For each `### Step N:` section in order:
 6. Determine result: exit code 0 → PASS, non-zero → FAIL, CLI missing → SKIPPED
 
 ```bash
-# Example step execution
-timeout ${TIMEOUT} bash -c '{step_command}' > step-${N}.stdout 2> step-${N}.stderr
+# Example step execution — portable timeout chain
+# Prefer `lib/exec-with-timeout.mjs` (Node wrapper) when available;
+# otherwise use the shell fallback below. GNU `timeout` is absent from stock
+# macOS and Windows Git Bash, so chain `timeout → gtimeout → bare`.
+if command -v timeout >/dev/null 2>&1; then
+  timeout "${TIMEOUT:-120}" bash -c '{step_command}' > "step-${N}.stdout" 2> "step-${N}.stderr"
+elif command -v gtimeout >/dev/null 2>&1; then
+  gtimeout "${TIMEOUT:-120}" bash -c '{step_command}' > "step-${N}.stdout" 2> "step-${N}.stderr"
+else
+  echo "warn: no timeout/gtimeout on PATH; running without enforced timeout" >&2
+  bash -c '{step_command}' > "step-${N}.stdout" 2> "step-${N}.stderr"
+fi
 EXIT_CODE=$?
 ```
 


### PR DESCRIPTION
Wave 5 of the [2026-04-21 audit](https://github.com/mikeparcewski/wicked-testing/issues/28). Stacks cleanly on main after #77 merged; 8 audit issues close when this merges.

## What changed

### Commit 1 — install cluster + #50 + #73 (mine)

Closes #50, #59, #60, #64, #67, #73, #74.

- **`lib/exec-with-timeout.mjs`** (#50) — Node-enforced step timeout. Replaces GNU `timeout` shell-out that assumed coreutils; stock macOS has no `/usr/bin/timeout`. Structured result with stdout/stderr/exitCode/timedOut/durationMs; shell-string and argv-form both supported; `runStep()` companion returns the evidence-shape the executor already writes.
- **Copilot target removed** (#59) — `~/.github/skills` collided with GitHub dotfiles and was never read by `gh copilot`. Dropped from `CLI_TARGETS` until a real integration point exists.
- **Per-CLI identity markers** (#60) — each target declares `identityMarkers`; a bare `~/.claude/` directory with none of `settings.json` / `plugins/` / `projects/` no longer triggers a silent install there. New `--assume-cli=<name>` override for power users.
- **Writable-path preflight** (#64) — each target install is wrapped in try/catch with `accessSync(dir, W_OK)`. Read-only homes produce `[target] SKIPPED — EACCES` instead of a raw Node stack; other targets still run.
- **`plugin.json` auto-synced from disk** (#67) — `scripts/dev/sync-plugin-version.mjs` now regenerates `skills` / `agents` / `commands` arrays too. Previously 5 skills declared vs 11 on disk / 10 commands vs 14. Regenerated; `npm test` now gates against drift.
- **Isolation tier surfaced globally** (#73) — each target carries `isolationTier: "hard"` (Claude) or `"advisory"` (everyone else). Install prints an ADVISORY warning per non-Claude target; doctor shows the tier in every install-integrity line.
- **Doctor is the diagnostic framework the docs promised** (#74) — structured `{ name, status, message, fix }` per check: node version, CLI detection, sqlite, per-target install integrity (spot-checks expected agent files non-empty), schema version vs code, plugin.json drift. Colored pass/warn/fail badges with remediation hints.

### Commit 2 — #66 cross-platform shell cleanup (parallel worker)

Closes #66.

- 20 Unix-only shell constructs across 9 inventoried files + 4 bonus scenario examples fixed. Replacement patterns:
  - `/tmp/` → `${TMPDIR:-${TEMP:-/tmp}}` chain (Unix + Windows Git Bash)
  - Bare `timeout` → `command -v timeout` / `gtimeout` / warn-and-bare fallback, with note pointing at `lib/exec-with-timeout.mjs` (#50) as the preferred Node path
  - `find . -name` / `2>/dev/null || true` / `ls | wc -l` → Python one-liners with `python3 || python` dual-fallback
- `scripts/dev/validate.mjs` gains a `checkCrossPlatform()` gate that scans fenced `bash`/`sh` blocks in agents/skills/commands/scenarios for the 9 banned patterns and warns on regression. Tree is currently clean (0 warnings).

## Verified

- `npm test` passes (0 errors, 0 warnings — first time the tree has been clean on cross-platform).
- `doctor` reports green across 8 checks (Node, 4 CLIs, better-sqlite3, schema, plugin.json).
- `plugin.json` regenerated: 11 skills / 32 agents / 14 commands — matches disk.
- `npx wicked-testing --version` → `0.2.0` (Wave 1 stays working).
- `check --require=^0.2.0` → exit 0 (Wave 1 stays working).
- Install on a non-Claude target prints the advisory-tier warning.

## Parallelization note

This PR was produced with a subagent tackling #66 in a git worktree while I worked on the install cluster + #50 + #73 in the main tree. Their commit (`5610a23`) and mine (`5709c43`) landed on independent file sets with zero conflicts.

## What's next

Per the [10-wave plan](https://github.com/mikeparcewski/wicked-testing/issues/28#issuecomment-4290790087):

- **Wave 6** — skills/agents wiring cleanup (#57, #58, #61, #62, #63)
- **Wave 7** — evals ecosystem (#40, #65, #71) + deferred Wave-3 eval cases
- **Waves 8–10** — coverage expansion, docs reconciliation, P2 polish