### PR TITLE
Audit wave 7a: eval runner infrastructure

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,87 @@
+name: Evals
+
+# Two-tier eval execution:
+#
+#   1. `check-all` — structural validation of every evals/<agent>/evals.json.
+#      Runs on every PR. Fast, no API cost, catches malformed cases before
+#      they reach reviewers. Required check.
+#
+#   2. `dispatch` — optional, opt-in via workflow_dispatch. Actually runs
+#      each case against a Claude model and verifies assertions. Requires
+#      an ANTHROPIC_API_KEY secret; the job skips cleanly when absent so
+#      contributors without the secret can still trigger the workflow for
+#      the structural half.
+#
+# The dispatch half of Wave 7 evaluations (real Claude calls) lands in a
+# follow-up PR with per-agent invocation logic. This workflow ships the
+# gate + structural-check today so PRs that add bad case files get caught
+# immediately.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'evals/**'
+      - 'scripts/dev/evals.mjs'
+      - '.github/workflows/evals.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'evals/**'
+      - 'scripts/dev/evals.mjs'
+  workflow_dispatch:
+    inputs:
+      dispatch_full_run:
+        description: 'Run full eval dispatch (requires ANTHROPIC_API_KEY secret)'
+        required: false
+        default: 'false'
+
+jobs:
+  check-all:
+    name: structural validation (every PR)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm install
+      - run: node scripts/dev/evals.mjs check-all
+
+  dispatch:
+    # Gated: only runs when a maintainer invokes workflow_dispatch with
+    # the explicit opt-in flag AND the secret is available. Every other
+    # event (PR open, push, automated dispatch) skips cleanly.
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.dispatch_full_run == 'true'
+    needs: check-all
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm install
+      - name: skip if no API key
+        if: ${{ secrets.ANTHROPIC_API_KEY == '' }}
+        run: |
+          echo "::warning::ANTHROPIC_API_KEY not set — skipping dispatch."
+          exit 0
+      - name: dispatch evals (per-agent)
+        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          echo "::notice::Full dispatch pending Wave 7b — runner hook exists but has no driver yet."
+          # Placeholder: Wave 7b adds scripts/dev/run-evals-dispatch.mjs that
+          # actually calls the Anthropic SDK per case. For now the workflow
+          # is wired and the check-all gate runs — dispatch is a no-op with
+          # a notice.
+          exit 0
+      - name: upload iteration artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-iteration
+          path: .claude/skills/wicked-testing-evals/workspace/iteration-*/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/evals/README.md
+++ b/evals/README.md
@@ -3,6 +3,11 @@
 Per-agent eval test cases for wicked-testing. Invoked on-demand via the
 `wicked-testing-evals` dev skill or `node scripts/dev/evals.mjs`.
 
+Runner infrastructure lives in `scripts/dev/evals.mjs` — see audit #71 for
+the Wave 7a rebuild that added `not-contains-text`, `ledger-matches-manifest`,
+`dispatches-agent`, tighter `produces-artifact`, model pinning, `evals:run`,
+and the `check-all` structural gate.
+
 ## Layout
 
 ```
@@ -18,16 +23,29 @@ evals/
 {
   "agent": "test-designer",
   "subagent_type": "wicked-testing:test-designer",
+  "description": "Optional free-form summary",
+
+  // Reproducibility pins (Wave 7a / #71). None are executed by the runner
+  // itself — the host CLI's dispatcher is responsible for honoring them.
+  // Recording them here puts the pin in the report.json so a red result
+  // two weeks later can be reproduced against the same model.
+  "model_pin":   "claude-sonnet-4-5",     // string; host CLI dispatcher honors
+  "temperature": 0,                        // number; 0 = greediest reproducible
+  "seed":        1,                        // integer; optional
+
   "cases": [
     {
       "id": 1,
       "prompt": "Run the login-bad-credentials scenario and emit a verdict.",
       "input_files": ["scenarios/examples/login-bad-credentials.md"],
       "expected_shape": "manifest",
+      "model_override": null,   // per-case override of model_pin (rare)
       "assertions": [
-        { "kind": "produces-artifact", "path": ".wicked-testing/evidence/*/manifest.json" },
+        { "kind": "produces-artifact", "path": ".wicked-testing/evidence/*/manifest.json",
+          "min_bytes": 200, "contains_regex": "\"verdict\"" },
         { "kind": "manifest-valid",    "schema": "schemas/evidence.json" },
-        { "kind": "verdict-in",        "values": ["PASS", "FAIL", "N-A", "SKIP"] }
+        { "kind": "verdict-in",        "values": ["PASS", "FAIL", "N-A", "SKIP"] },
+        { "kind": "not-contains-text", "values": ["STUB", "TODO"] }
       ]
     }
   ]
@@ -36,23 +54,52 @@ evals/
 
 ## Assertion kinds
 
-| Kind                  | Meaning                                                       |
-|-----------------------|---------------------------------------------------------------|
-| `produces-artifact`   | Agent writes a file matching the glob                         |
-| `manifest-valid`      | Output matches `schemas/evidence.json`                        |
-| `verdict-in`          | Verdict field is one of the allowed values                    |
-| `contains-text`       | Output contains a substring                                   |
-| `matches-regex`       | Output matches a regex                                        |
-| `json-has-key`        | JSON output has a specific key                                |
-| `exit-code-zero`      | Runner exit code is 0                                         |
+| Kind                      | Meaning                                                                                 |
+|---------------------------|-----------------------------------------------------------------------------------------|
+| `produces-artifact`       | Agent writes a file matching the glob. Optional `min_bytes` + `contains_regex` strict.  |
+| `manifest-valid`          | Output matches `schemas/evidence.json` (required top-level keys).                       |
+| `verdict-in`              | Verdict field is one of the allowed values.                                             |
+| `contains-text`           | Output contains a substring. Case-insensitive by default; `case_sensitive: true` opt.   |
+| `not-contains-text`       | Output does NOT contain any value in `values` (or `value`). Critical for refusal cases. |
+| `matches-regex`           | Output matches `pattern` (supports inline `(?i)` or explicit `flags`).                  |
+| `exit-code-zero`          | Runner exit code is 0.                                                                  |
+| `ledger-matches-manifest` | SQLite ledger's `runs.status` + `verdicts.verdict` agree with `manifest.json`. Catches dual-write drift. |
+| `dispatches-agent`        | Skill-level: the dispatch trace names the expected `subagent_type`. Used for skill evals. |
 
 Assertion kinds are deterministic — no LLM judging. The LLM runs the agent;
-the assertions are mechanical checks on the result.
+the assertions are mechanical checks on the captured output.
+
+### Tightening `produces-artifact`
+
+Previously `produces-artifact` passed if ANY file matched the glob — a
+0-byte TODO stub would pass an `.test.js` assertion. Wave 7a added two
+optional fields:
+
+- `min_bytes: 200` — every matched file must be at least 200 bytes.
+- `contains_regex: "\"verdict\""` — every matched file must contain the regex
+  (use `contains_flags: "i"` for case-insensitive).
+
+Both are additive — existing cases keep their old behavior.
+
+## Runner commands
+
+```bash
+node scripts/dev/evals.mjs list                       # inventory eval sets
+node scripts/dev/evals.mjs plan <agent>               # show cases + cost estimate
+node scripts/dev/evals.mjs run  <agent>               # plan + model-pin info
+node scripts/dev/evals.mjs check <agent> <iteration>  # verify a captured run
+node scripts/dev/evals.mjs check-all                  # structural validation (CI-safe)
+```
+
+`check-all` is the gate for `.github/workflows/evals.yml` — a PR that adds
+a case with a bogus assertion kind or a duplicate case id fails before the
+reviewer sees it.
 
 ## Cost discipline
 
 Evals dispatch the real agent via Claude API, which costs tokens. The runner
 prints an estimate before running and requires `--yes` to skip confirmation
-on large runs (≥ 10 cases). Results cache in `.claude/skills/wicked-testing-evals/workspace/iteration-N/`.
+on large runs (≥ 10 cases). Results cache in
+`.claude/skills/wicked-testing-evals/workspace/iteration-N/`.
 
 See `.claude/skills/wicked-testing-evals/SKILL.md` for the runner workflow.

--- a/scripts/dev/evals.mjs
+++ b/scripts/dev/evals.mjs
@@ -98,6 +98,20 @@ function walk(dir) {
   return out;
 }
 
+// Shared regex parser — honors an inline `(?flags)` prefix the way the old
+// matches-regex branch did, so contains_regex (produces-artifact) and
+// matches-regex stay consistent. Returns a compiled RegExp or throws.
+function compileRegex(pattern, explicitFlags = "") {
+  let src = pattern;
+  let flags = explicitFlags;
+  const inline = src.match(/^\(\?([a-z]+)\)/);
+  if (inline) {
+    flags = (flags + inline[1]).split("").filter((v, i, s) => s.indexOf(v) === i).join("");
+    src = src.slice(inline[0].length);
+  }
+  return new RegExp(src, flags);
+}
+
 function checkAssertion(a, ctx) {
   switch (a.kind) {
     case "produces-artifact": {
@@ -117,16 +131,14 @@ function checkAssertion(a, ctx) {
         }
       }
       if (a.contains_regex) {
-        try {
-          const re = new RegExp(a.contains_regex, a.contains_flags || "");
-          const missing = matched.filter(f => {
-            try { return !re.test(readFileSync(f, "utf8")); } catch { return true; }
-          });
-          if (missing.length > 0) {
-            return { pass: false, detail: `${missing.length}/${matched.length} file(s) missing /${a.contains_regex}/` };
-          }
-        } catch (e) {
-          return { pass: false, detail: `invalid contains_regex: ${e.message}` };
+        let re;
+        try { re = compileRegex(a.contains_regex, a.contains_flags || ""); }
+        catch (e) { return { pass: false, detail: `invalid contains_regex: ${e.message}` }; }
+        const missing = matched.filter(f => {
+          try { return !re.test(readFileSync(f, "utf8")); } catch { return true; }
+        });
+        if (missing.length > 0) {
+          return { pass: false, detail: `${missing.length}/${matched.length} file(s) missing /${a.contains_regex}/` };
         }
       }
       return { pass: true, detail: `matched ${matched.length} file(s)` };
@@ -169,21 +181,11 @@ function checkAssertion(a, ctx) {
     }
     case "matches-regex": {
       const out = existsSync(ctx.outputFile) ? readFileSync(ctx.outputFile, "utf8") : "";
-      // Translate inline (?i) flag — JS uses the flags argument instead
-      let pattern = a.pattern;
-      let flags = a.flags || "";
-      const inlineFlags = pattern.match(/^\(\?([a-z]+)\)/);
-      if (inlineFlags) {
-        flags = (flags + inlineFlags[1]).split("").filter((v, i, s) => s.indexOf(v) === i).join("");
-        pattern = pattern.slice(inlineFlags[0].length);
-      }
-      try {
-        const re = new RegExp(pattern, flags);
-        const match = re.test(out);
-        return { pass: match, detail: match ? "matched" : `no match for /${pattern}/${flags}` };
-      } catch (e) {
-        return { pass: false, detail: `invalid regex: ${e.message}` };
-      }
+      let re;
+      try { re = compileRegex(a.pattern, a.flags || ""); }
+      catch (e) { return { pass: false, detail: `invalid regex: ${e.message}` }; }
+      const match = re.test(out);
+      return { pass: match, detail: match ? "matched" : `no match for ${re}` };
     }
     case "exit-code-zero": {
       return { pass: ctx.exitCode === 0, detail: `exit=${ctx.exitCode ?? "n/a"}` };
@@ -196,10 +198,12 @@ function checkAssertion(a, ctx) {
       const out = existsSync(ctx.outputFile) ? readFileSync(ctx.outputFile, "utf8") : "";
       const values = Array.isArray(a.values) ? a.values : (a.value != null ? [a.value] : []);
       if (values.length === 0) return { pass: false, detail: "not-contains-text needs `values` array or `value`" };
-      const leaked = values.filter(v => a.case_sensitive
-        ? out.includes(v)
-        : out.toLowerCase().includes(String(v).toLowerCase())
-      );
+      // Lowercase the haystack once, not once per value. Coerce every
+      // needle to a string up front so a caller passing an integer ("42")
+      // doesn't crash on `.includes()`.
+      const haystack = a.case_sensitive ? out : out.toLowerCase();
+      const needles = values.map(v => a.case_sensitive ? String(v) : String(v).toLowerCase());
+      const leaked = needles.filter(n => haystack.includes(n));
       return { pass: leaked.length === 0, detail: leaked.length ? `leaked: ${leaked.map(s => JSON.stringify(s)).join(", ")}` : "clean" };
     }
     case "ledger-matches-manifest": {

--- a/scripts/dev/evals.mjs
+++ b/scripts/dev/evals.mjs
@@ -12,11 +12,18 @@
 //   node scripts/dev/evals.mjs list                 # list eval sets
 //   node scripts/dev/evals.mjs plan <agent>         # show cases + cost estimate
 //   node scripts/dev/evals.mjs check <agent> <run>  # check assertions on a captured run
+//   node scripts/dev/evals.mjs run <agent>          # print plan + run instructions
+//   node scripts/dev/evals.mjs check-all            # structural validation of all evals.json
+//
+// Assertion kinds: produces-artifact, manifest-valid, verdict-in,
+// contains-text, not-contains-text, matches-regex, exit-code-zero,
+// ledger-matches-manifest, dispatches-agent. See evals/README.md.
 
 import { readFileSync, readdirSync, existsSync, statSync, writeFileSync, mkdirSync } from "node:fs";
 import { join, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const REPO = resolve(__dirname, "..", "..");
@@ -95,7 +102,34 @@ function checkAssertion(a, ctx) {
   switch (a.kind) {
     case "produces-artifact": {
       const matched = globMatch(join(ctx.caseDir, a.path), walk(ctx.caseDir));
-      return { pass: matched.length > 0, detail: matched.length ? `matched ${matched.length} file(s)` : "no matching file" };
+      if (matched.length === 0) {
+        return { pass: false, detail: "no matching file" };
+      }
+      // Optional strictness — guards against the "any empty file passes"
+      // false-positive the original assertion had. Cases can opt in via
+      // `min_bytes` or `contains_regex` without breaking existing cases.
+      if (typeof a.min_bytes === "number") {
+        const small = matched.filter(f => {
+          try { return statSync(f).size < a.min_bytes; } catch { return true; }
+        });
+        if (small.length > 0) {
+          return { pass: false, detail: `${small.length} file(s) below ${a.min_bytes}-byte minimum` };
+        }
+      }
+      if (a.contains_regex) {
+        try {
+          const re = new RegExp(a.contains_regex, a.contains_flags || "");
+          const missing = matched.filter(f => {
+            try { return !re.test(readFileSync(f, "utf8")); } catch { return true; }
+          });
+          if (missing.length > 0) {
+            return { pass: false, detail: `${missing.length}/${matched.length} file(s) missing /${a.contains_regex}/` };
+          }
+        } catch (e) {
+          return { pass: false, detail: `invalid contains_regex: ${e.message}` };
+        }
+      }
+      return { pass: true, detail: `matched ${matched.length} file(s)` };
     }
     case "manifest-valid": {
       const manifests = walk(ctx.caseDir).filter(f => f.endsWith("manifest.json"));
@@ -154,9 +188,177 @@ function checkAssertion(a, ctx) {
     case "exit-code-zero": {
       return { pass: ctx.exitCode === 0, detail: `exit=${ctx.exitCode ?? "n/a"}` };
     }
+    case "not-contains-text": {
+      // Negative form of contains-text. Critical for self-grading-refusal
+      // cases — we need to assert the executor did NOT emit "PASS"/"FAIL"
+      // tokens, not just that it emitted something that happens to include
+      // the word "reviewer". See audit #42 + #75.
+      const out = existsSync(ctx.outputFile) ? readFileSync(ctx.outputFile, "utf8") : "";
+      const values = Array.isArray(a.values) ? a.values : (a.value != null ? [a.value] : []);
+      if (values.length === 0) return { pass: false, detail: "not-contains-text needs `values` array or `value`" };
+      const leaked = values.filter(v => a.case_sensitive
+        ? out.includes(v)
+        : out.toLowerCase().includes(String(v).toLowerCase())
+      );
+      return { pass: leaked.length === 0, detail: leaked.length ? `leaked: ${leaked.map(s => JSON.stringify(s)).join(", ")}` : "clean" };
+    }
+    case "ledger-matches-manifest": {
+      // Dual-write consistency check: the manifest written to the evidence
+      // dir must agree with the SQLite ledger on run_id, verdict, status,
+      // and evidence_path. Catches the class of bug where the manifest
+      // says PASS but the `verdicts` row says FAIL (or vice versa), which
+      // is invisible to every other assertion kind. See audit #40 + #42.
+      const manifests = walk(ctx.caseDir).filter(f => f.endsWith("manifest.json"));
+      if (manifests.length === 0) return { pass: false, detail: "no manifest.json" };
+      let manifest;
+      try { manifest = JSON.parse(readFileSync(manifests[0], "utf8")); }
+      catch (e) { return { pass: false, detail: `manifest parse: ${e.message}` }; }
+      const dbPath = a.db_path
+        ? resolve(ctx.caseDir, a.db_path)
+        : join(ctx.caseDir, ".wicked-testing", "wicked-testing.db");
+      if (!existsSync(dbPath)) return { pass: false, detail: `no sqlite ledger at ${relative(ctx.caseDir, dbPath)}` };
+      try {
+        // Use sqlite3 CLI via node's child_process — avoids an import cycle
+        // into better-sqlite3 from a pure-JS runner, and tolerates a JSON-only
+        // DomainStore. execFileSync is imported at the top of this file.
+        const escId = (manifest.run_id || "").replace(/[^0-9a-f-]/gi, "");
+        if (!escId) return { pass: false, detail: "manifest has no run_id" };
+        const sql = `SELECT status, evidence_path FROM runs WHERE id = '${escId}';`;
+        const rows = execFileSync("sqlite3", ["-json", dbPath, sql], { encoding: "utf8" });
+        const parsed = JSON.parse(rows || "[]");
+        if (parsed.length === 0) return { pass: false, detail: `no runs row for ${escId}` };
+        const ledgerStatus = parsed[0].status;
+        const ledgerPath = parsed[0].evidence_path;
+        if (ledgerStatus !== manifest.status) {
+          return { pass: false, detail: `status drift: ledger=${ledgerStatus} manifest=${manifest.status}` };
+        }
+        // Verdict agreement — look up in verdicts table
+        const vRows = JSON.parse(execFileSync("sqlite3", [
+          "-json", dbPath, `SELECT verdict FROM verdicts WHERE run_id = '${escId}' ORDER BY created_at DESC LIMIT 1;`
+        ], { encoding: "utf8" }) || "[]");
+        if (vRows.length === 0) return { pass: false, detail: `no verdicts row for ${escId}` };
+        const mVerdict = typeof manifest.verdict === "string" ? manifest.verdict : manifest.verdict?.value;
+        if (vRows[0].verdict !== mVerdict) {
+          return { pass: false, detail: `verdict drift: ledger=${vRows[0].verdict} manifest=${mVerdict}` };
+        }
+        return { pass: true, detail: `agree: status=${ledgerStatus} verdict=${mVerdict} path=${ledgerPath}` };
+      } catch (e) {
+        return { pass: false, detail: `ledger check failed: ${e.message}` };
+      }
+    }
+    case "dispatches-agent": {
+      // Skill-level assertion: the captured trace shows a Task() dispatch
+      // to the named subagent_type. The trace lives at
+      // `${caseDir}/dispatch.trace` — a plain text file the host CLI's
+      // eval dispatcher writes alongside output.md. Skill evals need this
+      // because the artifact they produce is "the right subagent was
+      // invoked" more than "the right file landed on disk". See audit #65.
+      const tracePath = join(ctx.caseDir, a.trace_file || "dispatch.trace");
+      if (!existsSync(tracePath)) {
+        return { pass: false, detail: `no dispatch trace at ${relative(ctx.caseDir, tracePath)}` };
+      }
+      const trace = readFileSync(tracePath, "utf8");
+      const target = a.value || a.subagent_type;
+      if (!target) return { pass: false, detail: "dispatches-agent needs `value` or `subagent_type`" };
+      const found = trace.includes(target);
+      return { pass: found, detail: found ? `found ${target}` : `${target} not in trace` };
+    }
     default:
       return { pass: false, detail: `unknown assertion kind: ${a.kind}` };
   }
+}
+
+// Structural validation of every evals.json — used by check-all so a PR that
+// adds a malformed case file fails CI instead of shipping.
+const KNOWN_ASSERTION_KINDS = new Set([
+  "produces-artifact",
+  "manifest-valid",
+  "verdict-in",
+  "contains-text",
+  "not-contains-text",
+  "matches-regex",
+  "exit-code-zero",
+  "ledger-matches-manifest",
+  "dispatches-agent",
+]);
+
+function validateEvalSet(agentDir) {
+  const file = join(EVALS_DIR, agentDir, "evals.json");
+  if (!existsSync(file)) return [{ agent: agentDir, severity: "error", message: "missing evals.json" }];
+  let data;
+  try { data = JSON.parse(readFileSync(file, "utf8")); }
+  catch (e) { return [{ agent: agentDir, severity: "error", message: `parse error: ${e.message}` }]; }
+
+  const problems = [];
+  if (!Array.isArray(data.cases)) {
+    problems.push({ agent: agentDir, severity: "error", message: "evals.json missing `cases` array" });
+    return problems;
+  }
+  const seenIds = new Set();
+  for (const c of data.cases) {
+    if (c.id == null) {
+      problems.push({ agent: agentDir, severity: "error", message: "case missing `id`" });
+      continue;
+    }
+    if (seenIds.has(c.id)) {
+      problems.push({ agent: agentDir, severity: "error", message: `duplicate case id: ${c.id}` });
+    }
+    seenIds.add(c.id);
+    if (!Array.isArray(c.assertions)) {
+      problems.push({ agent: agentDir, severity: "error", message: `case ${c.id}: missing assertions array` });
+      continue;
+    }
+    for (const a of c.assertions) {
+      if (!a.kind) {
+        problems.push({ agent: agentDir, severity: "error", message: `case ${c.id}: assertion missing kind` });
+      } else if (!KNOWN_ASSERTION_KINDS.has(a.kind)) {
+        problems.push({ agent: agentDir, severity: "error", message: `case ${c.id}: unknown assertion kind '${a.kind}'` });
+      }
+    }
+  }
+  return problems;
+}
+
+function checkAll() {
+  if (!existsSync(EVALS_DIR)) { console.log("No evals/ directory."); return; }
+  const entries = readdirSync(EVALS_DIR)
+    .filter(d => { try { return statSync(join(EVALS_DIR, d)).isDirectory(); } catch { return false; } });
+  const allProblems = [];
+  let scanned = 0;
+  for (const d of entries) {
+    const problems = validateEvalSet(d);
+    scanned++;
+    for (const p of problems) allProblems.push(p);
+  }
+  if (allProblems.length === 0) {
+    console.log(`evals:check-all — ${scanned} eval set(s), all structurally valid.`);
+    process.exit(0);
+  }
+  console.error(`evals:check-all — ${allProblems.length} problem(s) across ${scanned} eval set(s):`);
+  for (const p of allProblems) {
+    console.error(`  ${p.severity.toUpperCase()} ${p.agent}: ${p.message}`);
+  }
+  process.exit(1);
+}
+
+function runAgent(agent) {
+  // `run` is plan + runtime instructions in one. The actual dispatch still
+  // happens in the host CLI's Agent tool — this runner cannot drive the
+  // Claude API directly (see header comment). What we CAN do is show the
+  // caller exactly where to write outputs and how to invoke the checker.
+  if (!agent) { console.error("Usage: evals.mjs run <agent>"); process.exit(1); }
+  const file = join(EVALS_DIR, agent, "evals.json");
+  if (!existsSync(file)) { console.error(`No eval set for agent: ${agent}`); process.exit(1); }
+  const data = JSON.parse(readFileSync(file, "utf8"));
+  planAgent(agent);
+  console.log(`\n--- runtime ---`);
+  console.log(`Model pin: ${data.model_pin || "(none — results will drift with host model)"}`);
+  console.log(`Temperature pin: ${data.temperature != null ? data.temperature : "(none)"}`);
+  console.log(`Seed pin: ${data.seed != null ? data.seed : "(none)"}`);
+  console.log();
+  console.log(`For each case, dispatch Task(subagent_type="${data.subagent_type}", ...)`);
+  console.log(`Write output to: ${relative(REPO, WORKSPACE)}/iteration-<N>/${agent}/case-<id>/output.md`);
+  console.log(`Then verify: node scripts/dev/evals.mjs check ${agent} iteration-<N>`);
 }
 
 function checkRun(agent, iteration) {
@@ -200,13 +402,17 @@ function checkRun(agent, iteration) {
 }
 
 switch (cmd) {
-  case "list":  listAgents();          break;
-  case "plan":  planAgent(rest[0]);    break;
-  case "check": checkRun(rest[0], rest[1]); break;
+  case "list":      listAgents();            break;
+  case "plan":      planAgent(rest[0]);      break;
+  case "run":       runAgent(rest[0]);       break;
+  case "check":     checkRun(rest[0], rest[1]); break;
+  case "check-all": checkAll();              break;
   default:
     console.log(`Usage:
-  evals.mjs list
-  evals.mjs plan <agent>
-  evals.mjs check <agent> <iteration>`);
+  evals.mjs list                            list every eval set
+  evals.mjs plan <agent>                    plan a run for <agent>
+  evals.mjs run <agent>                     plan + runtime pin info
+  evals.mjs check <agent> <iteration>       verify assertions for a captured run
+  evals.mjs check-all                       structural validation of every evals.json (CI-safe)`);
     process.exit(1);
 }


### PR DESCRIPTION
Wave 7a of the [2026-04-21 audit](https://github.com/mikeparcewski/wicked-testing/issues/28). Runner foundation that unblocks every other Wave 7 eval issue. **Closes #71.** Actual new eval cases land in Wave 7b.

## What ships

### 3 new assertion kinds (`scripts/dev/evals.mjs`)

- **`not-contains-text`** — negative form of contains-text. Unblocks #42 (executor self-grading refusal) and #75 (tighten loose regexes). Lets cases assert the executor did NOT emit \`PASS\` / \`FAIL\` tokens, not just that its output happens to include the word "reviewer".
- **`ledger-matches-manifest`** — opens SQLite via the sqlite3 CLI and confirms `runs.status` + `verdicts.verdict` agree with `manifest.json`. Catches the dual-write drift class of bug. Unblocks #40 + #42.
- **`dispatches-agent`** — skill-level assertion. The captured dispatch trace (`${caseDir}/dispatch.trace`) names the expected `subagent_type`. Unblocks #65 (skill evals).

### Tighter `produces-artifact`

Old assertion passed if any file matched the glob — a 0-byte TODO stub passed. Added optional `min_bytes` + `contains_regex` (plus `contains_flags`). Additive; existing cases unaffected.

### Reproducibility pins

`model_pin`, `temperature`, `seed`, and per-case `model_override` are documented and stored in report.json so red results can be reproduced weeks later against the same model. Honored by the host dispatcher; recorded by the runner.

### New runner commands

- `evals:run <agent>` — plan + runtime pin info in one invocation. The single-entry-point UX #71 asked for.
- `evals:check-all` — structural validation of all 32 eval sets. Catches typo'd assertion kinds, duplicate case ids, missing arrays, parse errors. Exits 0 when clean.

### CI gate (`.github/workflows/evals.yml`)

- `check-all` runs on every PR touching `evals/**` or the runner. Fast, no API cost, required check.
- `dispatch` is gated on `workflow_dispatch` + ANTHROPIC_API_KEY secret; currently a placeholder that skips cleanly. Wave 7b ships the per-case Anthropic SDK driver.
- Artifact upload for failed iteration workspaces (14-day retention).

## Verified

- `node scripts/dev/evals.mjs check-all` → `32 eval set(s), all structurally valid` (exit 0)
- `node scripts/dev/evals.mjs run <agent>` shows plan + pin info
- Existing `check <agent> <iteration>` works against real + synthetic fixtures
- `npm test` clean (0 errors, 0 warnings)

## What's next

Wave 7b lands the eval cases themselves:
- #41 reviewer isolation adversarial cases (needs the new assertion kinds this PR adds)
- #42 executor self-grading refusal tightening
- #43 oracle routing (12 named queries)
- #40 e2e pipeline + dual-write via `ledger-matches-manifest`
- #65 skill evals via `dispatches-agent`
- #68 writer / scenario-executor negatives
- #75 per-eval depth regex tightening