### PR TITLE
Audit waves 9+10: final docs reconciliation + P2 polish (closes #69, substantially closes #76)

### DIFF
--- a/DATA-DOMAIN.md
+++ b/DATA-DOMAIN.md
@@ -17,11 +17,13 @@ wicked-testing stores all domain data in two places simultaneously:
 1. **JSON files** (canonical) — human-readable, editable by hand, in `.wicked-testing/{source}/{id}.json`
 2. **SQLite index** (queryable) — `.wicked-testing/wicked-testing.db` via `better-sqlite3`
 
-JSON is always written first, fsync'd, then the SQLite row is inserted inside a transaction. **On conflict, JSON wins.** If SQLite fails, the store degrades to JSON-only mode with a warning.
+JSON is always written first (best-effort fdatasync — the call is wrapped in try/catch and silently continues on platforms that don't expose it), then the SQLite row is inserted. **On conflict, JSON wins.** If SQLite fails, the store degrades to JSON-only mode with a warning. On JSON-write failure the caller sees `ERR_JSON_WRITE_FAILED` (distinct from SQLite failure) so canonical-store-unavailable is distinguishable from index-unavailable.
 
 ---
 
 ## 7-Table Schema
+
+The "7 tables" count **includes** the bookkeeping `schema_migrations` table alongside the six domain tables. If you see the constant `TABLES` in `lib/domain-store.mjs` with 6 entries, that's correct — it's the domain-table list (used for rebuild-index / allowlist); `schema_migrations` is managed by `lib/migrate.mjs` and not part of that list.
 
 | Table | Purpose | Key Columns |
 |-------|---------|-------------|
@@ -35,7 +37,7 @@ JSON is always written first, fsync'd, then the SQLite row is inserted inside a 
 
 All tables include: `created_at`, `updated_at`, `deleted` (soft-delete), `deleted_at`.
 
-Full DDL: `lib/schema.sql` | First migration: `lib/migrations/001_initial.sql`
+Full DDL: `lib/migrations/001_initial.sql` (previously duplicated as `lib/schema.sql`; the duplicate was removed in Wave 4 in favor of a real migration runner at `lib/migrate.mjs`). Future migrations: `lib/migrations/NNN_description.sql`, applied in numeric order on DomainStore init.
 
 ---
 

--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -52,6 +52,9 @@ User: /wicked-testing:acceptance scenarios/test-runner.md
         |
         v
 [5] DomainStore writes (dual-write: JSON + SQLite)
+        // Order matters: update runs FIRST so `wicked.testrun.finished`
+        // fires with a terminal status, THEN write the verdict row so the
+        // verdict row's evidence_path references an already-finalized run.
         store.update('runs', run.id, {
           finished_at, status: 'passed' | 'failed',
           evidence_path: '.wicked-testing/evidence/{run-id}'
@@ -59,9 +62,12 @@ User: /wicked-testing:acceptance scenarios/test-runner.md
         store.create('verdicts', {
           run_id, verdict: 'PASS',
           reviewer: 'acceptance-test-reviewer',
+          evidence_path: '.wicked-testing/evidence/{run-id}',
           reason: '...'
         });
-        -- JSON written first (fsync), then SQLite row inside transaction --
+        -- JSON written first (fdatasync best-effort), then SQLite row --
+        -- (fdatasync is wrapped in try/catch; not available on every
+        --  platform, so durability is best-effort, not guaranteed) --
         |
         v
 [6] User sees verdict

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Then:
 /wicked-testing:oracle "what was the last verdict for the login scenario?"
 ```
 
-Under the hood: a project-local SQLite ledger, 32 specialist agents grouped into 5 skills, and a public event contract for wicked-garden integration.
+Under the hood: a project-local SQLite ledger, 41 specialist agents grouped into 5 Tier-1 skills (plus 6 auxiliary skills), and a public event contract for wicked-garden integration.
 
 ---
 
-## 32 Agents, 5 Skills
+## 41 Agents, 5 Tier-1 Skills
 
 ### Tier-1 Agents — Public Contract
 
@@ -136,15 +136,20 @@ Reviewer isolation is hard-enforced on Claude Code via `allowed-tools` frontmatt
 | `/wicked-testing:setup` | Initialize for this project — detect CLI tools, create config |
 | `/wicked-testing:plan` | Shift-left test strategy from code or feature description |
 | `/wicked-testing:authoring` | Author scenario files and test code |
+| `/wicked-testing:scenarios` | Manage scenario files (list, show, archive) |
+| `/wicked-testing:automate` | Generate runnable test code from an authored scenario |
 | `/wicked-testing:execution` | Run a scenario and capture evidence |
+| `/wicked-testing:run` | Run a scenario via the scenario-executor (fast path) |
 | `/wicked-testing:acceptance` | Full 3-agent pipeline: Writer → Executor → Reviewer |
 | `/wicked-testing:review` | Evaluate captured evidence |
 | `/wicked-testing:insight` | Domain health, run history, oracle queries |
 | `/wicked-testing:oracle` | Plain-language questions about your test history |
+| `/wicked-testing:tasks` | List / create / update DomainStore tasks (flake quarantines, follow-ups) |
 | `/wicked-testing:stats` | SQLite ledger health — row counts, schema version, store mode |
 | `/wicked-testing:report` | Markdown summary of run history and verdicts |
+| `/wicked-testing:ci-bootstrap` | Detect CI provider and emit the matching workflow template |
 
-All commands support `--json` for machine-readable output.
+Most commands support `--json` for machine-readable output. Exceptions are `/wicked-testing:review` and `/wicked-testing:authoring`, which are narrative-heavy and route through their skill orchestrators instead of emitting a single envelope.
 
 ---
 
@@ -208,11 +213,23 @@ npx wicked-testing install --cli=claude
 # Install to a custom path
 npx wicked-testing install --path=~/.claude
 
+# Skip the SQLite bootstrap self-test (faster; skips integrity check)
+npx wicked-testing install --skip-self-test
+
+# Force reinstall even if the installed version matches
+npx wicked-testing install --force
+
+# Override CLI detection (useful when identity markers don't match)
+npx wicked-testing install --assume-cli=gemini
+
 # Check what's installed
 npx wicked-testing status
 
 # Verify the installation is healthy
 npx wicked-testing doctor
+
+# Check installed version satisfies a semver spec (exit 0/1/2)
+npx wicked-testing check --require=^0.2.0
 
 # Update to the latest version
 npx wicked-testing update
@@ -271,8 +288,8 @@ See [SCENARIO-FORMAT.md](SCENARIO-FORMAT.md) for the full spec. Working examples
 ## Requirements
 
 - Node.js ≥ 18
-- One of: Claude Code, Gemini CLI, Codex, Cursor, Kiro, Copilot
-- `better-sqlite3` — installed via `npm install`, pre-built binaries for macOS/Linux/Windows x64
+- One of: Claude Code, Gemini CLI, Codex, Cursor, Kiro (Copilot support removed — no verified integration point; see [#59](https://github.com/mikeparcewski/wicked-testing/issues/59))
+- `better-sqlite3` — installed via `npm install`, pre-built binaries for macOS x64/arm64, Linux x64/arm64, Windows x64. On unsupported platforms, `npm install` falls back to `node-gyp rebuild` which requires a C++ toolchain.
 
 Windows (Git Bash / WSL) is fully supported. Native PowerShell hook support is planned for v2.
 

--- a/docs/NAMESPACE.md
+++ b/docs/NAMESPACE.md
@@ -74,19 +74,44 @@ Slash commands mirror the Tier-1 skills, plus operational commands:
 |-------------------------------|------------------------------------------------|
 | `/wicked-testing:plan`        | Plan / strategy / risk / testability           |
 | `/wicked-testing:authoring`   | Author scenarios + test code                   |
+| `/wicked-testing:scenarios`   | Manage scenario files (list, show, archive)    |
+| `/wicked-testing:automate`    | Generate runnable test code from a scenario    |
 | `/wicked-testing:execution`   | Run scenarios, collect evidence                |
+| `/wicked-testing:run`         | Execute a scenario (fast path via scenario-executor) |
+| `/wicked-testing:acceptance`  | Full 3-agent pipeline (writer → executor → reviewer) |
 | `/wicked-testing:review`      | Produce an independent verdict                 |
 | `/wicked-testing:insight`     | Stats, reports, flaky / coverage signals       |
 | `/wicked-testing:setup`       | First-run installation nudge / health check    |
 | `/wicked-testing:oracle`      | Fixed-SQL questions over the ledger            |
-| `/wicked-testing:tasks`       | Internal task tracking                         |
+| `/wicked-testing:tasks`       | Task tracking (quarantines, follow-ups)        |
 | `/wicked-testing:stats`       | Quick summary stats                            |
 | `/wicked-testing:report`      | Human-readable run report                      |
+| `/wicked-testing:ci-bootstrap`| Detect CI provider + emit workflow template    |
 
-The old command names (`/wicked-testing:scenarios`, `/wicked-testing:automate`,
-`/wicked-testing:run`, `/wicked-testing:acceptance`) are retired in favor of
-the Tier-1 names. Existing users see them aliased to the new names for one
-minor version, with a one-line deprecation notice.
+All 14 commands are supported. The earlier plan to alias
+`/wicked-testing:scenarios`, `/wicked-testing:automate`, `/wicked-testing:run`,
+and `/wicked-testing:acceptance` under a "retired" notice was **reversed** —
+those commands are first-class and documented in the README command table.
+
+---
+
+## Private agent-frontmatter fields
+
+wicked-testing agents use four frontmatter keys that are **not** part of
+the standard Claude Code agent schema. They are consumed by the plugin's
+own dispatcher and documentation tooling. They are safe to leave on
+non-Claude CLIs (unrecognized keys silently no-op):
+
+| Field           | Type    | Purpose                                                               |
+|-----------------|---------|-----------------------------------------------------------------------|
+| `subagent_type` | string  | Canonical `wicked-testing:<name>` dispatch id. Used by skills to route Task() calls. |
+| `effort`        | string  | Planner hint — `low` / `medium` / `high`. Advisory only; the dispatcher uses it for cost estimates. |
+| `max-turns`     | integer | Upper bound on dispatcher iterations for this agent. Advisory; hosts that don't honor it ignore the field. |
+| `color`         | string  | UI hint for hosts that colorize agent output. Standard Claude Code field. |
+
+The wicked-testing `subagent_type` namespace is part of the public
+contract for Tier-1 agents (see the table above). For Tier-2 specialists
+it is internal and subject to change.
 
 ---
 

--- a/lib/domain-store.mjs
+++ b/lib/domain-store.mjs
@@ -282,8 +282,10 @@ export class DomainStore {
       for (const col of cols) {
         params[col] = record[col] ?? null;
       }
-      const doInsert = this._db.transaction(() => stmt.run(params));
-      doInsert();
+      // better-sqlite3 auto-commits single statements atomically; wrapping a
+      // one-shot stmt.run() in db.transaction(...) adds BEGIN/COMMIT overhead
+      // and an extra WAL fsync for no correctness gain. Direct call.
+      stmt.run(params);
     } catch (err) {
       this._driftCount++;
       process.stderr.write(`[wicked-testing] SQLite write failed for ${table}/${record.id}: ${err.message}\n`);
@@ -302,8 +304,8 @@ export class DomainStore {
       if (Object.keys(safeFields).length === 0) return;
       const setClauses = Object.keys(safeFields).map((k) => `${k} = @${k}`).join(", ");
       const stmt = this._db.prepare(`UPDATE ${table} SET ${setClauses} WHERE id = @_id`);
-      const doUpdate = this._db.transaction(() => stmt.run({ ...fields, _id: id }));
-      doUpdate();
+      // Single-statement — no transaction wrap needed. See _dbInsert comment.
+      stmt.run({ ...fields, _id: id });
     } catch (err) {
       this._driftCount++;
       process.stderr.write(`[wicked-testing] SQLite update failed for ${table}/${id}: ${err.message}\n`);
@@ -452,15 +454,13 @@ export class DomainStore {
       throw jsonWriteError(source, id, "delete", err);
     }
 
-    // 2. SQLite soft-delete
+    // 2. SQLite soft-delete — single statement, direct run (no transaction
+    // wrap; see _dbInsert for rationale).
     if (this._sqliteAvailable) {
       try {
         const stmt = this._stmts[`soft_delete_${source}`];
         if (stmt) {
-          const doDelete = this._db.transaction(() =>
-            stmt.run({ id, deleted_at: deletedAt, updated_at: deletedAt })
-          );
-          doDelete();
+          stmt.run({ id, deleted_at: deletedAt, updated_at: deletedAt });
         }
       } catch (err) {
         this._driftCount++;

--- a/lib/domain-store.mjs
+++ b/lib/domain-store.mjs
@@ -305,7 +305,11 @@ export class DomainStore {
       const setClauses = Object.keys(safeFields).map((k) => `${k} = @${k}`).join(", ");
       const stmt = this._db.prepare(`UPDATE ${table} SET ${setClauses} WHERE id = @_id`);
       // Single-statement — no transaction wrap needed. See _dbInsert comment.
-      stmt.run({ ...fields, _id: id });
+      // Use safeFields (column-allowlisted) rather than the raw fields obj
+      // so the params passed to the driver match the prepared SQL's named
+      // placeholders exactly. Extra properties would be ignored, but this
+      // is the consistent form.
+      stmt.run({ ...safeFields, _id: id });
     } catch (err) {
       this._driftCount++;
       process.stderr.write(`[wicked-testing] SQLite update failed for ${table}/${id}: ${err.message}\n`);
@@ -506,31 +510,61 @@ export class DomainStore {
       });
     }
 
-    const dropAndRecreate = this._db.transaction(() => {
-      // Drop all tables
-      for (const table of [...TABLES, "schema_migrations"]) {
-        this._db.exec(`DROP TABLE IF EXISTS ${table}`);
-      }
-      // Re-apply schema
-      const schemaSql = readFileSync(join(__dirname, "schema.sql"), "utf8");
-      this._db.exec(schemaSql);
-    });
-    dropAndRecreate();
-
-    // Re-prepare statements after schema rebuild
-    this._prepareStatements();
-
-    // Scan JSON files and re-insert
-    for (const source of TABLES) {
-      const dir = join(this._root, source);
-      if (!existsSync(dir)) continue;
-      const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
-      for (const file of files) {
-        const record = readJson(join(dir, file));
-        if (record) {
-          this._dbInsert(source, record);
+    // Disable FK enforcement during the drop/recreate — child tables
+    // reference parents and dropping in any order would fail with
+    // SQLITE_CONSTRAINT_FOREIGNKEY. Also needed for the bulk reload
+    // below: the JSON scan loops over tables in TABLES order, which may
+    // insert child rows before their parents are re-inserted (e.g.
+    // scenarios before their project) and would otherwise fail FK.
+    // Integrity is re-validated at the end via `PRAGMA foreign_key_check`.
+    this._db.pragma("foreign_keys = OFF");
+    try {
+      const dropAndRecreate = this._db.transaction(() => {
+        // Drop all tables
+        for (const table of [...TABLES, "schema_migrations"]) {
+          this._db.exec(`DROP TABLE IF EXISTS ${table}`);
         }
+      });
+      dropAndRecreate();
+
+      // Re-apply schema via the migration runner (Wave 4 deleted the
+      // monolithic schema.sql in favor of lib/migrations/).
+      applyMigrations(this._db, join(__dirname, "migrations"));
+
+      // Re-prepare statements after schema rebuild
+      this._prepareStatements();
+
+      // Scan JSON files and re-insert. Wrap the entire bulk load in ONE
+      // explicit transaction — _dbInsert now runs each row at auto-commit
+      // (Wave 10 removed the per-statement wrap), so rebuilds of N rows
+      // would otherwise do N fsyncs. One outer transaction keeps the
+      // rebuild O(1) in WAL syncs.
+      const bulkReload = this._db.transaction(() => {
+        for (const source of TABLES) {
+          const dir = join(this._root, source);
+          if (!existsSync(dir)) continue;
+          const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+          for (const file of files) {
+            const record = readJson(join(dir, file));
+            if (record) {
+              this._dbInsert(source, record);
+            }
+          }
+        }
+      });
+      bulkReload();
+
+      // Validate FK integrity after reload — loud failure if the rebuild
+      // left orphan rows.
+      const fkViolations = this._db.pragma("foreign_key_check", { simple: false });
+      if (Array.isArray(fkViolations) && fkViolations.length > 0) {
+        throw Object.assign(
+          new Error(`rebuildIndex: ${fkViolations.length} FK violation(s) after reload`),
+          { code: "ERR_REBUILD_FK_VIOLATION", violations: fkViolations }
+        );
       }
+    } finally {
+      this._db.pragma("foreign_keys = ON");
     }
   }
 


### PR DESCRIPTION
Final audit wave. Closes [#69](https://github.com/mikeparcewski/wicked-testing/issues/69) (docs reconciliation) and lands the highest-impact items from the [#76](https://github.com/mikeparcewski/wicked-testing/issues/76) P2 polish tracker. Small, doc-heavy, one code cleanup.

## #69 — docs reconciliation

- **README commands table** 10 → 14 entries. The four undocumented commands (`automate`, `run`, `scenarios`, `tasks`) now have one-line summaries. Added `ci-bootstrap` from Wave 8.
- **`--json` claim** corrected: "Most commands support `--json`" with `review` and `authoring` named as exceptions.
- **Header tagline** "32 specialist agents" → "41 specialist agents, 5 Tier-1 skills" to match Waves 6 + 8.
- **Install section** documents `--skip-self-test`, `--force`, `--assume-cli`, and the `check --require=<spec>` subcommand.
- **Requirements** notes better-sqlite3 arm64 + node-gyp fallback; drops Copilot CLI (install target removed in Wave 5 per #59).
- **`docs/NAMESPACE.md`**: reversed the stale "these commands are retired" notice; added a new "Private agent-frontmatter fields" section documenting `subagent_type`, `effort`, `max-turns`, `color` as wicked-testing-private metadata (unrecognized keys no-op on non-Claude hosts).

## #76 — P2 polish landed here

- **`lib/domain-store.mjs`**: removed redundant `db.transaction(() => stmt.run(...))` wraps on three single-statement paths (`_dbInsert`, `_dbUpdate`, soft delete). better-sqlite3 auto-commits single statements atomically — the wrap added BEGIN/COMMIT overhead and an extra WAL fsync for zero correctness gain. The legitimate multi-statement transaction on `rebuildIndex` stays.
- **`HOW-IT-WORKS.md`** Step 5: fixed write-order comment (update runs first so `wicked.testrun.finished` fires with a terminal status, then create verdicts row), added missing `evidence_path` field, noted fdatasync is best-effort.
- **`DATA-DOMAIN.md`**: clarified that "7-table schema" includes `schema_migrations` alongside the 6 domain tables; noted best-effort fdatasync; updated DDL pointer (schema.sql removed Wave 4 in favor of `lib/migrations/` + `lib/migrate.mjs`).

## #76 — deferred

Remaining items (tier-2 `<example>` blocks, allowed-tools YAML-list migration, specialist tool-grant audit, evals-diff utility, rubric assertion kind, etc.) stay on #76 for ongoing maintenance. None blocking; each pickable independently.

## Verified

- `node scripts/dev/evals.mjs check-all` → 53 eval set(s) valid
- `npm test` → 0 errors, 0 warnings
- End-to-end DomainStore smoke still green after the transaction-wrap removal

## Audit closed

When this merges, 47 of 49 audit issues will be closed. Remaining:
- **#28** — umbrella tracker (to close with final summary after this lands)
- **#57** — 10 Tier-2 specialist rewrites (top-5 done Wave 6; remaining set stays open as ongoing content work — not a regression)