### PR TITLE
Release v0.3.0: update skill + audit bump + CHANGELOG

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-testing",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Standalone QE library — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, optional wicked-bus + wicked-brain integration.",
   "skills": [
     {
@@ -57,6 +57,11 @@
       "name": "wicked-testing:test-strategy",
       "path": "skills/test-strategy/SKILL.md",
       "command": "/wicked-testing:test-strategy"
+    },
+    {
+      "name": "wicked-testing:update",
+      "path": "skills/update/SKILL.md",
+      "command": "/wicked-testing:update"
     }
   ],
   "agents": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,83 @@
+# Changelog
+
+All notable changes to `wicked-testing`. Format loosely follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
+[SemVer](https://semver.org/).
+
+## [0.3.0] — 2026-04-21
+
+First release after the end-to-end audit (see [#28](https://github.com/mikeparcewski/wicked-testing/issues/28)). Seven PRs landed 48 of 49 audit findings; this release cuts a version from the resulting main branch. No breaking API changes for consumers that followed the public contract documented in `docs/INTEGRATION.md` (the reshape of drifted claims is in doc surface only).
+
+### Added
+
+- **New Tier-1 skill: `wicked-testing:update`** — checks for and installs updates to the published npm package, refreshes skills / agents / commands across every detected AI CLI, verifies the upgrade landed.
+- **9 new Tier-2 specialists** (roster 16 → 25):
+  - `test-impact-analyzer` — diff → ranked affected scenarios
+  - `release-readiness-engineer` — aggregates verdicts + flakes + risk + SLO → GO/CONDITIONAL/NO-GO
+  - `security-test-engineer` — SAST/DAST/secrets/authz with OWASP ASVS traceability
+  - `ai-feature-test-engineer` — prompt-injection, hallucination, judge ≠ SUT isolation
+  - `iac-test-engineer` — terraform/checkov/opa/kyverno/helm/cfn-guard
+  - `compliance-test-engineer` — SOC2/HIPAA/GDPR/PCI control mapping
+  - `snapshot-hygiene-auditor` — snapshot rot/over-broad/rubber-stamp detection
+  - `test-code-quality-auditor` — assertion-free, tautological, swallowing tests etc.
+  - `incident-to-scenario-synthesizer` — stack trace → reproducible scenario
+- **Top-5 Tier-2 specialists rewritten** with concrete tool invocations, DomainStore integration, evidence outputs, failure-mode taxonomies, auto-invoke examples: `a11y-test-engineer`, `chaos-test-engineer`, `flaky-test-hunter`, `mutation-test-engineer`, `visual-regression-engineer`.
+- **Bus-event emission** via `lib/bus-emit.mjs` (previously a no-op stub). Six-event public catalog now fires at the right DomainStore CRUD sites: `wicked.scenario.authored`, `wicked.teststrategy.authored`, `wicked.testrun.started`, `wicked.testrun.finished`, `wicked.verdict.recorded`, `wicked.evidence.captured`.
+- **Evidence manifest producer** `lib/manifest.mjs` — writes contract-compliant `.wicked-testing/evidence/<run-id>/manifest.json` with sha256-hashed artifacts, inline shape validation.
+- **Context validator** `lib/context-md-validator.mjs` — pre-dispatch scrub of prejudicial patterns in reviewer `context.md` (verdict assignments, run_id references, historical counts, executor chain-of-thought leaks).
+- **Node-enforced step timeout** `lib/exec-with-timeout.mjs` — replaces the GNU `timeout` shell dependency (absent on stock macOS).
+- **Migration runner** `lib/migrate.mjs` — versioned, self-bootstrapping, per-file transactioned. Replaces the duplicated `lib/schema.sql` path.
+- **New CLI subcommand** `check --require=<spec>` — consumer-facing semver compatibility check (=, ^, ~, >=, >, <=, <; honors strict SemVer for 0.x.y).
+- **New install flags** `--assume-cli=<name>` (override identity-marker detection) and `--skip-self-test` (documented in README).
+- **Install-time isolation-tier warning** — per-target advisory for non-Claude hosts where `allowed-tools` is prompt-enforced, not host-enforced.
+- **Doctor diagnostic framework** — 8 structured checks with colored badges and remediation hints: node version, CLI detection, `better-sqlite3`, per-target install integrity, schema version, `plugin.json` drift.
+- **Eval runner infrastructure** — `evals:run`, `evals:check-all`, 3 new assertion kinds (`not-contains-text`, `ledger-matches-manifest`, `dispatches-agent`), tighter `produces-artifact` (`min_bytes`, `contains_regex`), model-pin fields (`model_pin`, `temperature`, `seed`).
+- **CI gate for evals** — `.github/workflows/evals.yml` runs `check-all` on every PR touching `evals/**` or the runner.
+- **CI integration templates** — GitHub Actions, GitLab, Jenkins, Buildkite; new `commands/ci-bootstrap.md` detects provider and emits the right template; `docs/CI.md` chapter covering exit-code contract, artifact publishing, PR-comment summary, secrets, headless mode, caching.
+- **Eval coverage** grew 32 → 53 sets: 11 new skill-level eval sets (`evals/skills/**`), pipeline end-to-end eval, reviewer isolation adversarial cases, oracle per-query routing + obfuscation cases, writer/executor negative cases, tightened a11y/load-perf/strategist/flaky assertions.
+
+### Fixed
+
+- `--version` / `-v` / `--help` / `-h` flags now route to the matching subcommand (previously silently ran `install`). Session-start consumer probes — including wicked-garden's — now parse the bare semver.
+- Evidence path unified at `.wicked-testing/evidence/<run-id>/` across every skill / command / agent (previously drifted between `runs/` and `evidence/`).
+- RUN_ID uses the DomainStore-assigned UUID; no more 1-second-granularity collisions between parallel pipelines.
+- `test-designer` constrained to `Read, Write, Bash, Grep, Glob` (stripped `Agent`, `Skill`, `Edit`); body marked as dev-loop fast path with explicit self-grading warning. Default verdict dispatch in `skills/execution/SKILL.md` now routes to the 3-agent pipeline.
+- Scenario body is no longer inlined into the writer's prompt — passes path only; writer reads with its own `Read` tool and treats contents as data, not instructions.
+- DomainStore SQL interpolation of `${source}` / `${table}` now validates against the TABLES allowlist — `ERR_INVALID_SOURCE` on anything unexpected.
+- DomainStore is now a real singleton per resolved root.
+- Stale `.tmp.<n>` files get swept on init; runs stuck in `'running'` > 1h get reclaimed to `errored` with `wicked.testrun.finished` emission.
+- `atomicWriteJson` failures now wrap with `ERR_JSON_WRITE_FAILED` (distinct from SQLite failures).
+- `buildOracleQuery` param order fixed — no more double-push of `since`/`project` values for templated queries like `runs_by_status`.
+- `rebuildIndex` now uses the migration runner (latent `schema.sql` reference from Wave 4 was broken), wraps bulk reload in one outer transaction to keep WAL syncs O(1), and runs with `PRAGMA foreign_keys = OFF` + a `foreign_key_check` audit at the end so reloads don't blow up on drop/insert order.
+- 20 Unix-only shell constructs across 9 files replaced with portable equivalents (`${TMPDIR:-${TEMP:-/tmp}}`, `python3 || python` fallback, Node exec-with-timeout). `scripts/dev/validate.mjs` gained a `checkCrossPlatform()` gate to prevent regressions.
+- `plugin.json` now auto-syncs from disk (`skills`, `agents`, `commands` arrays + version) on `prepublishOnly` and `npm test` — the historical 11-on-disk / 5-registered / 14-on-disk / 10-registered drift is gone.
+- Doctor `plugin.json` drift check added.
+- Docs reconciled: README command table complete (14 commands listed); `--json` claim corrected to name the two exceptions; Tier-2 table expanded; install section documents new flags; `docs/NAMESPACE.md` reversed stale "retired" notice and adds a section on private agent-frontmatter fields.
+- `HOW-IT-WORKS.md` Step 5 write order fixed; `DATA-DOMAIN.md` clarifies the 7-table count includes `schema_migrations` and notes `fdatasync` is best-effort.
+
+### Removed
+
+- `copilot` CLI target (was aimed at `~/.github/skills` — speculative path that collided with GitHub dotfiles; no verified Copilot integration point exists).
+- `lib/schema.sql` — duplicate of `lib/migrations/001_initial.sql`; migrations/ is now the single source of truth.
+- Three invented event names from README (`wicked.testrun.completed`, `wicked.scenario.registered`, `wicked.oracle.queried`) — reconciled to the canonical names in `docs/INTEGRATION.md`.
+
+### Deferred
+
+- 10 pre-Wave-6 Tier-2 specialists still carry generic prose bodies (integration, ui-component, e2e-orchestrator, fuzz-property, localization, data-quality, observability, test-data-manager, exploratory-tester, coverage-archaeologist). Tracked in [#57](https://github.com/mikeparcewski/wicked-testing/issues/57); the Wave-6 pattern and eval harness are in place whenever time allows.
+- `allowed-tools` YAML-list migration across all agents, tier-2 `<example>` block additions, per-specialist tool-grant audit, `evals-diff` utility, rubric assertion kind — all queued on the P2 tracker for ongoing maintenance.
+
+## [0.2.0] — 2026-04-20
+
+Brain / bus integration for the 3-agent pipeline. (See [commit `cd748a5`](https://github.com/mikeparcewski/wicked-testing/commit/cd748a5).)
+
+## [0.1.2] — 2026-04-20
+
+Repo made public; provenance publishing unblocked.
+
+## [0.1.1] — 2026-04-20
+
+`package.json` `url` field fix.
+
+## [0.1.0] — 2026-04-11
+
+Initial release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-testing",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-testing",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-testing",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Standalone QE library for AI coding CLIs — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, 3-agent acceptance pipeline, bus+brain optional integration.",
   "keywords": [

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -168,8 +168,10 @@ stop. Warnings are OK to proceed past.
 For a one-line machine-readable summary:
 
 ```bash
-npx --yes wicked-testing doctor --json 2>&1 | python3 -c "import json,sys; d=json.load(sys.stdin); print(f\"healthy={d['healthy']} warnings={d['warnings']}\")" 2>/dev/null \
-  || npx --yes wicked-testing doctor --json 2>&1 | python -c "import json,sys; d=json.load(sys.stdin); print(f\"healthy={d['healthy']} warnings={d['warnings']}\")"
+# Keep stderr OFF the pipe — mixing warnings into the JSON stream
+# poisons the parser. We silence stderr at the outer level instead.
+npx --yes wicked-testing doctor --json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(f\"healthy={d['healthy']} warnings={d['warnings']}\")" 2>/dev/null \
+  || npx --yes wicked-testing doctor --json 2>/dev/null | python -c "import json,sys; d=json.load(sys.stdin); print(f\"healthy={d['healthy']} warnings={d['warnings']}\")"
 ```
 
 ### Step 6: Ledger schema auto-migrates on next use (no action needed)

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: wicked-testing:update
+description: |
+  Check for and install wicked-testing updates. Compares installed version
+  against npm registry, updates the published CLI, refreshes skills / agents
+  / commands across all detected AI CLIs (Claude Code, Gemini, Codex, Cursor,
+  Kiro), and verifies the upgrade landed.
+
+  Use when: "update wicked-testing", "check for updates", "wicked-testing:update",
+  or periodically to stay current.
+---
+
+# wicked-testing:update
+
+You check for and install updates to the published `wicked-testing` npm
+package and refresh the skills / agents / commands it drops into each
+detected AI CLI.
+
+Unlike `wicked-brain` (which runs a persistent server that must be
+restarted after upgrade), `wicked-testing` is a plugin — there is no
+server to restart, no in-memory state to reload. The update flow is just
+npm + skill-refresh, then a verify step.
+
+## Cross-Platform Notes
+
+Commands in this skill work on macOS, Linux, and Windows. Prefer your
+native tools (Read, Write, Grep, Glob) over shell commands when possible.
+
+## When to use
+
+- User asks to update or check for updates.
+- Periodically (suggest checking monthly).
+- After encountering behavior that might be fixed in a newer version.
+- Before opening a bug report — confirm the issue still reproduces on the
+  latest release so the maintainer doesn't chase a ghost.
+
+## Process
+
+### Step 1: Check current installed version
+
+Ask `wicked-testing` itself for its version. After Wave 1 (#32) the `--version`
+subcommand emits bare semver, so any shell can parse it directly without
+stripping a name prefix:
+
+```bash
+npx --yes wicked-testing --version 2>/dev/null || true
+```
+
+If nothing prints, the package was never installed globally (the user may
+have been invoking via `npx` only each time). Treat this as "needs install"
+and proceed to Step 4.
+
+If you need a machine-readable form (scripts, CI):
+
+```bash
+npx --yes wicked-testing --version --json 2>/dev/null || true
+# -> {"name":"wicked-testing","version":"0.2.0"}
+```
+
+**Alternative:** the `check` subcommand can gate on a range without
+printing the raw version:
+
+```bash
+npx --yes wicked-testing check --require="^0.2.0"
+# exit 0 = satisfies, 1 = does not satisfy, 2 = spec was unparseable
+```
+
+### Step 2: Check latest version on npm
+
+```bash
+npm view wicked-testing version 2>/dev/null || true
+```
+
+### Step 3: Compare versions
+
+If the installed version matches the latest, report:
+"wicked-testing is up to date (v{version})."
+
+If an update is available, ask the user:
+"wicked-testing v{new} is available (you have v{current}). Update now?"
+
+### Step 4: Update (if user approves)
+
+**Two artifacts move in lockstep:**
+
+1. The **npm package** — reinstalled so `npx wicked-testing` resolves to the
+   new version.
+2. The **skills / agents / commands** dropped into each detected AI CLI's
+   plugin directory (`~/.claude/`, `~/.gemini/`, `~/.codex/`, `~/.cursor/`,
+   `~/.kiro/`). These live outside the npm install; `npx wicked-testing install`
+   is what refreshes them from the updated package.
+
+Running only one of the two creates a split-brain where the CLI sees stale
+skill/agent files even though the npm package is fresh (or vice versa). Do
+both.
+
+```bash
+npm install -g wicked-testing@latest 2>&1
+```
+
+On Windows PowerShell (no change needed):
+```powershell
+npm install -g wicked-testing@latest
+```
+
+If this fails with `EACCES` / permission denied:
+- macOS/Linux: `sudo npm install -g wicked-testing@latest`
+- Windows: re-run the shell as Administrator, or fix npm's global prefix per
+  npm docs. Do NOT silently skip — report the failure and stop.
+
+Then refresh per-CLI deployments:
+
+```bash
+npx --yes wicked-testing install
+```
+
+This is idempotent — per-CLI markers (`.wicked-testing-version` inside the
+skills dir) skip CLIs that are already current. Pass `--force` to
+re-copy even when versions match. Options:
+
+```bash
+# Restrict to a subset of CLIs
+npx --yes wicked-testing install --cli=claude,gemini
+
+# Override identity-marker detection (use when the CLI's marker set diverges
+# from the built-in heuristic; see Wave 5 #60)
+npx --yes wicked-testing install --assume-cli=codex
+
+# Machine-readable per-target report
+npx --yes wicked-testing install --json
+```
+
+### Step 4a: Verify the update landed
+
+Re-run Step 1 and compare to Step 2:
+
+```bash
+npx --yes wicked-testing --version 2>/dev/null || true
+```
+
+The version reported MUST match the latest. If it still shows the old
+version:
+
+1. Check `which wicked-testing` (macOS/Linux) or `where wicked-testing` (Windows).
+   The shell may have cached a path to a different install.
+2. Clear npm's cache: `npm cache clean --force`, then re-run Step 4.
+3. Check whether a Node version manager (`nvm` / `fnm` / `volta`) is pinning a
+   stale copy via `nvm current` / `fnm current`.
+
+Do NOT proceed to Step 5 until the version check succeeds. Reporting a
+successful update while the CLI resolves to a stale binary is the top
+failure mode of this skill.
+
+### Step 5: Run doctor to confirm health
+
+The doctor subcommand runs structured diagnostics — node version, per-CLI
+install integrity (expected agent files present and non-empty), better-sqlite3
+loadability, SQLite schema version vs code, plugin.json drift (see Wave 5
+#74). Green doctor output is the "update succeeded" contract:
+
+```bash
+npx --yes wicked-testing doctor
+```
+
+If anything reports FAIL, share the remediation line with the user and
+stop. Warnings are OK to proceed past.
+
+For a one-line machine-readable summary:
+
+```bash
+npx --yes wicked-testing doctor --json 2>&1 | python3 -c "import json,sys; d=json.load(sys.stdin); print(f\"healthy={d['healthy']} warnings={d['warnings']}\")" 2>/dev/null \
+  || npx --yes wicked-testing doctor --json 2>&1 | python -c "import json,sys; d=json.load(sys.stdin); print(f\"healthy={d['healthy']} warnings={d['warnings']}\")"
+```
+
+### Step 6: Ledger schema auto-migrates on next use (no action needed)
+
+`wicked-testing`'s SQLite ledger lives at `.wicked-testing/wicked-testing.db`
+(per project). When a `wicked-testing` command next opens it, the migration
+runner in `lib/migrate.mjs` applies any pending migrations in order inside a
+transaction (see Wave 4 #52). No manual migration step is needed from this
+skill.
+
+If a project has a DB that was written by a NEWER version than the code,
+DomainStore refuses to write and prints: *"wicked-testing.db was written by
+a newer version (DB vN, code vM). Upgrade the plugin with: npm install -g
+wicked-testing@latest"*. This shouldn't happen after a successful update,
+but if it does the remediation is the same: redo Step 4.
+
+### Step 7: Report
+
+Tell the user what changed:
+
+```
+wicked-testing: v{old} -> v{new}
+Skills/agents/commands refreshed in: {list of CLI names}
+Doctor: {healthy|N warnings}
+```
+
+If the user opted not to update, report the current-vs-available gap and
+end.
+
+## Version check without updating
+
+If the user just wants to check (not update), stop after Step 3 and report:
+
+```
+Installed: v{current}
+Latest:    v{latest}
+```
+
+## Reading the changelog (optional but kind)
+
+Between Step 3 and Step 4, the user may want to see what changed. The
+repo publishes release notes on GitHub:
+
+```bash
+# Latest release notes — human-readable
+gh release view --repo mikeparcewski/wicked-testing 2>/dev/null \
+  || echo "gh not authenticated; see https://github.com/mikeparcewski/wicked-testing/releases"
+```
+
+Offer this before Step 4 if the gap is more than a patch bump (e.g., 0.2.x
+-> 0.3.0), so the user can skim new features and breaking changes before
+committing.


### PR DESCRIPTION
Release cut of the completed audit (#28) plus the long-missing update skill.

## Adds

- **`skills/update/SKILL.md`** — `wicked-testing:update` skill. Modeled after `wicked-brain:update` but adapted for the plugin shape (no server to restart; npm + per-CLI skill-refresh + doctor verify). Documents the two-artifact lockstep so users don't leave a half-upgraded tree. Notes the ledger's schema migrations auto-apply on next use via `lib/migrate.mjs` (no manual migrate step unlike wicked-brain's server-restart flow).
- **`CHANGELOG.md`** — new. 0.3.0 entry covers the Wave 1–10 audit scope (Added / Fixed / Removed / Deferred), plus backfilled short entries for 0.1.0 → 0.2.0 from git history.

## Version

`package.json` 0.2.0 → **0.3.0** (minor: lots of features + fixes, no breaking API change). `plugin.json` synced via `scripts/dev/sync-plugin-version.mjs`.

## Release flow

After this merges to main, I'll tag `v0.3.0`, which triggers `.github/workflows/release.yml`:
1. Test matrix (ubuntu / macos / windows)
2. `npm publish --provenance`
3. GitHub Packages publish

## Verified

- `node scripts/dev/evals.mjs check-all` → 53 eval set(s) valid
- `npm test` passes
- New skill passes the `checkCrossPlatform()` gate
- `plugin.json` regenerated (skills 11 → 12, version 0.2.0 → 0.3.0)