### PR TITLE
Release v0.3.1: Claude Code plugin registration + legacy-layout migration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "wicked-testing",
+  "owner": {
+    "name": "Mike Parcewski"
+  },
+  "plugins": [
+    {
+      "name": "wicked-testing",
+      "source": "./",
+      "description": "Standalone QE library for AI coding CLIs — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, 3-agent acceptance pipeline, optional wicked-bus + wicked-brain integration.",
+      "version": "0.3.1"
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-testing",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Standalone QE library — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, optional wicked-bus + wicked-brain integration.",
   "skills": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `wicked-testing`. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [SemVer](https://semver.org/).
 
+## [0.3.1] — 2026-04-21
+
+Claude Code install-path fix + stale-layout migration. No API changes; this is strictly about making the plugin actually load on Claude Code.
+
+### Added
+
+- **`.claude-plugin/marketplace.json`** — wicked-testing is now a proper Claude Code marketplace. Users can register it via:
+
+  ```bash
+  claude plugins marketplace add mikeparcewski/wicked-testing
+  claude plugins install wicked-testing
+  ```
+
+- **`install.mjs` migrates the pre-0.3 skill layout.** Older installs dropped skills under `~/.claude/skills/{acceptance-testing,browser-automation,scenario-authoring,test-oracle,test-runner,test-strategy}/` — unprefixed, orphaned after 0.3 switched to the `wicked-testing-<name>/` layout. `install.mjs` now detects those bare-name dirs (paranoid signature check — SKILL.md frontmatter `name:` must match the dir name AND the body must reference wicked-testing) and removes them on install. Same migration runs on uninstall. Collision-safe: generic names like `test-runner` that belong to other tools are left alone.
+
+- **`install.mjs` emits Claude Code–specific guidance.** When Claude Code is detected and wicked-testing isn't yet registered via `claude plugins`, the installer prints a prominent note pointing the user at the plugin-system install path. Silent when the `claude` binary isn't on PATH or the plugin is already registered.
+
+### Fixed
+
+- **README's Claude Code install command.** Was `claude plugins add mikeparcewski/wicked-testing` (not a valid command); now `claude plugins marketplace add mikeparcewski/wicked-testing` followed by `claude plugins install wicked-testing`.
+- **Install section rewritten** to explain the two install paths (plugin-system for Claude Code vs file-copy for Gemini / Codex / Cursor / Kiro) and why — Claude Code's skill resolver only surfaces skills from registered plugins, so the file-copy install leaves skills on disk but unloaded on Claude Code.
+
+### Background
+
+Surfaced during the v0.3.0 dogfood — `wicked-testing install` ran cleanly, doctor reported green, but Claude Code's `/reload-plugins` showed none of the 12 registered skills. Investigation found no `wicked-testing` entry in `~/.claude/plugins/installed_plugins.json`: the npm install path never registered the package with Claude Code's plugin system. The 6 bare-name skill dirs from April 11 were also on disk, compounding the confusion (generic `test-runner` / `test-strategy` names looked like they could be from any tool).
+
 ## [0.3.0] — 2026-04-21
 
 First release after the end-to-end audit (see [#28](https://github.com/mikeparcewski/wicked-testing/issues/28)). Seven PRs landed 48 of 49 audit findings; this release cuts a version from the resulting main branch. No breaking API changes for consumers that followed the public contract documented in `docs/INTEGRATION.md` (the reshape of drifted claims is in doc surface only).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ The industry answer has been scripted test frameworks: Playwright, pytest, k6, a
 ## What You Get
 
 ```bash
-claude plugins add mikeparcewski/wicked-testing
+claude plugins marketplace add mikeparcewski/wicked-testing
+claude plugins install wicked-testing
 ```
 
 Then:
@@ -200,11 +201,30 @@ When wicked-brain is present, wicked-testing writes memories on high-signal even
 
 ## Install
 
+Two install paths depending on which AI CLI you use:
+
+### Claude Code (plugin-system install)
+
+Claude Code only loads skills / agents / commands from **registered** plugins. Skills dropped into `~/.claude/skills/` without a plugin record are visible on disk but are NOT surfaced by the skill resolver. Register wicked-testing via Claude Code's marketplace system:
+
+```bash
+claude plugins marketplace add mikeparcewski/wicked-testing
+claude plugins install wicked-testing
+```
+
+The repo ships `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json` so Claude Code can discover everything.
+
+### Gemini CLI / Codex / Cursor / Kiro (file-copy install)
+
+These CLIs load skills directly from their home-relative skill directories (`~/.gemini/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, `~/.kiro/skills/`). For those:
+
 ```bash
 npx wicked-testing install
 ```
 
-Detects which AI CLIs are installed (`~/.claude/`, `~/.gemini/`, `~/.codex/`, etc.) and copies skills, agents, and commands into each. Runs a bootstrap self-test to verify the SQLite schema. Idempotent — safe to run multiple times.
+Detects which CLIs are present via identity markers (`config.json`, `settings.json`, etc.), copies skills / agents / commands into each, runs a bootstrap self-test, and prints a per-target isolation-tier note (hard-enforced on Claude Code, advisory on everyone else). Idempotent — safe to run multiple times.
+
+Running `npx wicked-testing install` on a machine with Claude Code detected WILL copy files to `~/.claude/skills/` for backward compatibility, but will also print a reminder to use `claude plugins install wicked-testing` for full integration.
 
 ```bash
 # Install for a specific CLI only

--- a/install.mjs
+++ b/install.mjs
@@ -279,7 +279,10 @@ function maybeEmitClaudeCodeGuidance(installedClaudeTarget) {
 // isn't on PATH or the command exited non-zero.
 function spawnSyncSafe(cmd, args) {
   try {
-    const r = spawnSync(cmd, args, { encoding: "utf8", timeout: 3000 });
+    // shell:true so Windows resolves .cmd / .bat shims on PATH (`claude.cmd`,
+    // etc.). Args are internal and trusted — no user input reaches this call,
+    // so there's no injection surface here.
+    const r = spawnSync(cmd, args, { encoding: "utf8", timeout: 3000, shell: true });
     if (r.error || r.status !== 0) return { ok: false, stdout: r.stdout || "" };
     return { ok: true, stdout: r.stdout || "" };
   } catch {

--- a/install.mjs
+++ b/install.mjs
@@ -10,6 +10,7 @@ import { join, resolve, basename } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { argv, exit } from "node:process";
 import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const home = homedir();
@@ -17,6 +18,23 @@ const home = homedir();
 const PKG = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
 const VERSION = PKG.version;
 const INSTALLED_MARKER = ".wicked-testing-version";
+
+// Bare-name skill directories from the pre-0.3 install layout. Older
+// installs dropped skills under ~/.claude/skills/{acceptance-testing,
+// browser-automation, scenario-authoring, test-oracle, test-runner,
+// test-strategy}/ — unprefixed. The 0.3 layout uses wicked-testing-<name>/
+// so those unprefixed dirs are now orphans (Claude Code only surfaces
+// skills from registered plugins, and generic names like "test-runner"
+// could collide with other tools). We migrate them away on install if
+// their SKILL.md still carries the wicked-testing signature.
+const LEGACY_BARE_SKILL_DIRS = [
+  "acceptance-testing",
+  "browser-automation",
+  "scenario-authoring",
+  "test-oracle",
+  "test-runner",
+  "test-strategy",
+];
 
 // Per-CLI target spec. `identityMarkers` is any of-list of filenames/dirs
 // that must exist inside the CLI's home-relative root before we'll install
@@ -182,6 +200,91 @@ function readdirSafe(p) { try { return readdirSync(p); } catch { return []; } }
 function copyTree(src, dest) {
   mkdirSync(dest, { recursive: true });
   cpSync(src, dest, { recursive: true, force: true });
+}
+
+// Migrate a single legacy bare-name skill dir. Returns true if removed.
+// Signature check: the dir must contain a SKILL.md whose frontmatter `name:`
+// matches the dir name AND whose body mentions "wicked-testing" — otherwise
+// it might belong to an unrelated tool and we leave it alone. Paranoid by
+// design because generic names like "test-runner" could reasonably be
+// owned by another plugin.
+function migrateOneLegacyDir(skillsDir, bareName) {
+  const path = join(skillsDir, bareName);
+  if (!existsSync(path)) return false;
+  const skillFile = join(path, "SKILL.md");
+  if (!existsSync(skillFile)) return false; // unknown dir shape — leave it
+  let body;
+  try { body = readFileSync(skillFile, "utf8"); } catch { return false; }
+  const nameMatch = body.match(/^name:\s*([A-Za-z0-9_:-]+)/m);
+  const frontmatterName = nameMatch ? nameMatch[1] : "";
+  // Signature: the SKILL.md's name field matches the dir AND body references
+  // wicked-testing. Two independent signals so we don't false-positive on
+  // a third-party plugin that happens to use the same dir name.
+  const isWickedTesting = frontmatterName === bareName && /wicked-testing/i.test(body);
+  if (!isWickedTesting) return false;
+  try {
+    rmSync(path, { recursive: true, force: true });
+    return true;
+  } catch { return false; }
+}
+
+function migrateLegacyLayout(targets) {
+  let total = 0;
+  const removed = [];
+  for (const t of targets) {
+    for (const bare of LEGACY_BARE_SKILL_DIRS) {
+      if (migrateOneLegacyDir(t.dir, bare)) {
+        removed.push(`${t.name}/${bare}`);
+        total++;
+      }
+    }
+  }
+  if (total > 0 && !jsonOut) {
+    console.log(`[migration] removed ${total} legacy bare-name skill dir(s) from the pre-0.3 layout:`);
+    for (const r of removed) console.log(`            ${r}`);
+  }
+  return removed;
+}
+
+// Claude Code uses a plugin-registration system distinct from the file-copy
+// install. Skills dropped into ~/.claude/skills/ without a plugin record are
+// visible on disk but NOT loaded by the skill resolver — see the release
+// notes for 0.3.1 / audit follow-up. We detect whether wicked-testing is
+// registered via Claude Code's plugin CLI and print a one-time guidance
+// block if not. Silent when the `claude` binary isn't on PATH (other CLIs
+// don't need this).
+function maybeEmitClaudeCodeGuidance(installedClaudeTarget) {
+  if (!installedClaudeTarget) return;
+  // `claude` binary present?
+  const probe = spawnSyncSafe("claude", ["--version"]);
+  if (!probe.ok) return;
+  // Is wicked-testing already registered with Claude Code?
+  const listing = spawnSyncSafe("claude", ["plugins", "list"]);
+  if (listing.ok && /(^|\s)wicked-testing(\s|$|@)/.test(listing.stdout || "")) return;
+  if (jsonOut) return; // structured consumers don't want prose guidance
+  console.log("");
+  console.log("\x1b[33mClaude Code note:\x1b[0m the file-copy install above drops skills into");
+  console.log("~/.claude/skills/ but Claude Code only loads skills from registered plugins.");
+  console.log("For full integration, also register the plugin:");
+  console.log("");
+  console.log("  \x1b[36mclaude plugins marketplace add mikeparcewski/wicked-testing\x1b[0m");
+  console.log("  \x1b[36mclaude plugins install wicked-testing\x1b[0m");
+  console.log("");
+  console.log("Other CLIs (Gemini / Codex / Cursor / Kiro) are loaded directly from the");
+  console.log("files copied above — no further action needed on those.");
+}
+
+// Tiny shell-free wrapper so both probes above stay synchronous and never
+// throw on ENOENT. Returns { ok, stdout } — `ok` is false if the binary
+// isn't on PATH or the command exited non-zero.
+function spawnSyncSafe(cmd, args) {
+  try {
+    const r = spawnSync(cmd, args, { encoding: "utf8", timeout: 3000 });
+    if (r.error || r.status !== 0) return { ok: false, stdout: r.stdout || "" };
+    return { ok: true, stdout: r.stdout || "" };
+  } catch {
+    return { ok: false, stdout: "" };
+  }
 }
 
 // --- subcommands -----------------------------------------------------------
@@ -453,6 +556,13 @@ async function cmdInstall({ mode }) {
   let totalSkills = 0, totalAgents = 0, totalCommands = 0;
   const perTargetReport = [];
 
+  // Clean the pre-0.3 layout (bare-name skill dirs) before we write the
+  // 0.3+ wicked-testing-<name>/ dirs — otherwise callers end up with a
+  // split-brain of stale and fresh skills under the same ~/.claude/skills/.
+  // migrateLegacyLayout is paranoid-signature-checked so it won't nuke a
+  // same-named dir that belongs to an unrelated plugin.
+  const migrated = migrateLegacyLayout(targets);
+
   for (const target of targets) {
     const existing = installedVersion(target);
     if (existing === VERSION && !force && mode !== "update") {
@@ -533,8 +643,18 @@ async function cmdInstall({ mode }) {
       skills: totalSkills,
       agents: totalAgents,
       commands: totalCommands,
+      legacy_layout_removed: migrated,
     }));
   }
+
+  // Claude-Code-specific guidance: skills dropped into ~/.claude/skills/
+  // without a plugin registration aren't loaded by the Claude Code skill
+  // resolver. Nudge the user toward `claude plugins marketplace add` +
+  // `claude plugins install` when wicked-testing isn't already registered.
+  const claudeInstalled = perTargetReport.find(
+    r => r.target === "claude" && (r.status === "installed" || r.status === "skipped" && r.reason === "already-current")
+  );
+  maybeEmitClaudeCodeGuidance(claudeInstalled);
 
   // Non-zero exit if any target skipped due to a real failure (not just
   // "already installed"). This matches CI expectations — an install script
@@ -558,6 +678,11 @@ function cmdUninstall() {
     for (const skill of skillDirs) {
       const p = join(target.dir, `wicked-testing-${skill}`);
       if (existsSync(p)) { rmSync(p, { recursive: true, force: true }); removed++; }
+    }
+    // Also clean pre-0.3 bare-name skill dirs if they're still ours
+    // (signature-checked — see migrateOneLegacyDir).
+    for (const bare of LEGACY_BARE_SKILL_DIRS) {
+      if (migrateOneLegacyDir(target.dir, bare)) removed++;
     }
     if (target.agentDir) {
       for (const f of agentFiles) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-testing",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-testing",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-testing",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "Standalone QE library for AI coding CLIs — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, 3-agent acceptance pipeline, bus+brain optional integration.",
   "keywords": [


### PR DESCRIPTION
Fixes the v0.3.0 dogfood finding: `wicked-testing install` ran cleanly and `doctor` reported green, but Claude Code's `/reload-plugins` didn't surface any of the 12 registered skills.

## Root cause

Claude Code only loads skills from plugins registered via its own plugin system (marketplace + install). The npm install path drops files into `~/.claude/skills/` but never registers wicked-testing with Claude Code — so the files are on disk but the skill resolver doesn't see them.

Three compounding issues:
1. No `.claude-plugin/marketplace.json` — repo can't be added as a marketplace
2. README said `claude plugins add mikeparcewski/wicked-testing` (not a valid subcommand — Claude Code's surface is `plugins marketplace add` + `plugins install`)
3. 6 bare-name skill dirs from the April-11 install layout (`~/.claude/skills/{acceptance-testing,browser-automation,scenario-authoring,test-oracle,test-runner,test-strategy}/`) still present on every upgrade, compounding the confusion

## Ships

### `.claude-plugin/marketplace.json` (new)

wicked-testing is its own marketplace. Install path:

```bash
claude plugins marketplace add mikeparcewski/wicked-testing
claude plugins install wicked-testing
```

Matches wicked-garden's pattern.

### `install.mjs` legacy-layout migration

New `migrateLegacyLayout()` runs on every install + uninstall. For each of the 6 pre-0.3 bare-name dirs per CLI target, it:

1. Checks the dir exists
2. Reads its `SKILL.md` frontmatter
3. Confirms `name:` matches the dir name **AND** the body contains `wicked-testing` (two independent signals)
4. If both pass → remove; otherwise leave alone

Paranoid by design — generic names like `test-runner` could belong to another plugin. Prints removals per-target:

```
[migration] removed 6 legacy bare-name skill dir(s) from the pre-0.3 layout:
            claude/acceptance-testing
            claude/browser-automation
            claude/scenario-authoring
            claude/test-oracle
            claude/test-runner
            claude/test-strategy
```

### `install.mjs` Claude Code guidance

Post-install, when Claude Code is detected and `claude plugins list` doesn't already name wicked-testing, the installer prints a prominent note pointing at the plugin-system install path. Silent when:

- The `claude` binary isn't on PATH
- wicked-testing is already registered
- `--json` (structured consumers don't want prose)

### README rewrite

Install section now opens with the Claude Code plugin-system flow and explains `npx wicked-testing install` as the path for Gemini / Codex / Cursor / Kiro. Fixed the bogus `claude plugins add ...` to the correct `marketplace add` + `install` pair.

## Verified locally

Tested end-to-end on my machine (which had all 6 stale bare-name dirs + a non-registered wicked-testing on Claude Code):

```
$ node install.mjs install --cli=claude --force
[migration] removed 6 legacy bare-name skill dir(s) from the pre-0.3 layout:
            claude/acceptance-testing
            ...
[claude] installed 0.3.1 (skills=12 agents=16+25 commands=15)

Claude Code note: the file-copy install above drops skills into
~/.claude/skills/ but Claude Code only loads skills from registered plugins.
For full integration, also register the plugin:

  claude plugins marketplace add mikeparcewski/wicked-testing
  claude plugins install wicked-testing
```

`npm test` passes.

## Version

0.3.0 → **0.3.1** (patch — bugfix for install UX, no API change).

## Release flow

Merge → tag `v0.3.1` → release workflow publishes to npm + GitHub Packages + creates the GitHub release.

## Follow-up (not blocking)

`scripts/dev/sync-plugin-version.mjs` should also sync `marketplace.json`'s `plugins[].version`. For 0.3.1 I bumped it manually; future releases should automate.