### PR TITLE
Release v0.3.2: fix Claude Code skill-loading (frontmatter namespace)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "wicked-testing",
       "source": "./",
-      "description": "Standalone QE library for AI coding CLIs — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, 3-agent acceptance pipeline, optional wicked-bus + wicked-brain integration.",
-      "version": "0.3.1"
+      "description": "Standalone QE library for AI coding CLIs \u2014 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, 3-agent acceptance pipeline, optional wicked-bus + wicked-brain integration.",
+      "version": "0.3.2"
     }
   ],
   "version": "1.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-testing",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Standalone QE library — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, optional wicked-bus + wicked-brain integration.",
   "skills": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `wicked-testing`. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [SemVer](https://semver.org/).
 
+## [0.3.2] — 2026-04-21
+
+Real fix for the "skills aren't loading in Claude Code" symptom. The v0.3.1 release misdiagnosed the cause as missing plugin registration and shipped a `marketplace.json` workaround. Turned out to be simpler: **6 of 12 `skills/*/SKILL.md` files had unprefixed `name:` frontmatter** (`name: test-runner` instead of `name: wicked-testing:test-runner`). Claude Code's skill resolver silently rejects skills whose frontmatter namespace doesn't match the plugin — when enough skills in a batch are broken, the whole plugin goes dark.
+
+### Fixed
+
+- **SKILL.md frontmatter `name:`** normalized to `wicked-testing:<name>` across all 12 Tier-1 + auxiliary skills. Previously `acceptance-testing`, `browser-automation`, `scenario-authoring`, `test-oracle`, `test-runner`, `test-strategy` had bare names and were being dropped. Now every SKILL.md's `name:` matches the Claude Code plugin-namespace convention (same pattern `wicked-brain` has always used — `wicked-brain:memory`, `wicked-brain:search`, etc.).
+- **`scripts/dev/validate.mjs`** now enforces `name == 'wicked-testing:<dir>'` on every skill. A PR that re-introduces the bare-name form fails `npm test` immediately. Prevents regression of the whole v0.3.1 issue category.
+
+### Changed
+
+- **README install section simplified.** `npx wicked-testing install` is the preferred path on every CLI including Claude Code — skills get dropped into `~/.claude/skills/wicked-testing-<name>/` and Claude Code picks them up directly (same as `wicked-brain-*/`). The `claude plugins marketplace add` path still works and remains documented as an optional alternative for users who prefer the plugin-system install flow. The v0.3.1 framing of "Claude Code REQUIRES plugin registration" was wrong.
+- **`install.mjs` post-install Claude Code guidance removed.** With the frontmatter fix, `npx wicked-testing install` works correctly for Claude Code; the "also run `claude plugins install`" nudge would now be misleading. The `.claude-plugin/marketplace.json` file from v0.3.1 stays on disk for users who prefer that path.
+
+### Kept from v0.3.1
+
+- `.claude-plugin/marketplace.json` — harmless and provides an alternative install path for plugin-system enthusiasts.
+- Legacy bare-name skill-dir migration in `install.mjs` — still needed to clean up the pre-0.3 layout on upgrade.
+
+### Debug trail
+
+The actual bug was caught by listing every dir under `~/.claude/skills/` with its frontmatter `name:` side-by-side, against `~/.claude/skills/wicked-brain-*/`. Same on-disk location, identical structure — but 6 of 12 wicked-testing frontmatter names were `<dir>` instead of `wicked-testing:<dir>`. wicked-brain was 23/23 correct. Claude Code's resolver was doing exactly what any sane resolver would do — reject skills whose frontmatter doesn't declare the right namespace.
+
 ## [0.3.1] — 2026-04-21
 
 Claude Code install-path fix + stale-layout migration. No API changes; this is strictly about making the plugin actually load on Claude Code.

--- a/README.md
+++ b/README.md
@@ -201,30 +201,20 @@ When wicked-brain is present, wicked-testing writes memories on high-signal even
 
 ## Install
 
-Two install paths depending on which AI CLI you use:
+```bash
+npx wicked-testing install
+```
 
-### Claude Code (plugin-system install)
+Detects which AI CLIs are present via identity markers (`config.json`, `settings.json`, `plugins/`, etc.), copies skills / agents / commands into each CLI's home-relative skill directory (`~/.claude/skills/`, `~/.gemini/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, `~/.kiro/skills/`), runs a bootstrap self-test, and prints a per-target isolation-tier note (hard-enforced on Claude Code, advisory on everyone else). Idempotent — safe to run multiple times.
 
-Claude Code only loads skills / agents / commands from **registered** plugins. Skills dropped into `~/.claude/skills/` without a plugin record are visible on disk but are NOT surfaced by the skill resolver. Register wicked-testing via Claude Code's marketplace system:
+**Claude Code users:** `npx wicked-testing install` is the preferred path and drops everything where Claude Code's skill resolver already looks. A `.claude-plugin/marketplace.json` also ships so you can register via the plugin-system install if you prefer:
 
 ```bash
 claude plugins marketplace add mikeparcewski/wicked-testing
 claude plugins install wicked-testing
 ```
 
-The repo ships `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json` so Claude Code can discover everything.
-
-### Gemini CLI / Codex / Cursor / Kiro (file-copy install)
-
-These CLIs load skills directly from their home-relative skill directories (`~/.gemini/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, `~/.kiro/skills/`). For those:
-
-```bash
-npx wicked-testing install
-```
-
-Detects which CLIs are present via identity markers (`config.json`, `settings.json`, etc.), copies skills / agents / commands into each, runs a bootstrap self-test, and prints a per-target isolation-tier note (hard-enforced on Claude Code, advisory on everyone else). Idempotent — safe to run multiple times.
-
-Running `npx wicked-testing install` on a machine with Claude Code detected WILL copy files to `~/.claude/skills/` for backward compatibility, but will also print a reminder to use `claude plugins install wicked-testing` for full integration.
+Both paths work; pick one.
 
 ```bash
 # Install for a specific CLI only

--- a/install.mjs
+++ b/install.mjs
@@ -10,7 +10,6 @@ import { join, resolve, basename } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { argv, exit } from "node:process";
 import { fileURLToPath } from "node:url";
-import { spawnSync } from "node:child_process";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const home = homedir();
@@ -244,50 +243,6 @@ function migrateLegacyLayout(targets) {
     for (const r of removed) console.log(`            ${r}`);
   }
   return removed;
-}
-
-// Claude Code uses a plugin-registration system distinct from the file-copy
-// install. Skills dropped into ~/.claude/skills/ without a plugin record are
-// visible on disk but NOT loaded by the skill resolver — see the release
-// notes for 0.3.1 / audit follow-up. We detect whether wicked-testing is
-// registered via Claude Code's plugin CLI and print a one-time guidance
-// block if not. Silent when the `claude` binary isn't on PATH (other CLIs
-// don't need this).
-function maybeEmitClaudeCodeGuidance(installedClaudeTarget) {
-  if (!installedClaudeTarget) return;
-  // `claude` binary present?
-  const probe = spawnSyncSafe("claude", ["--version"]);
-  if (!probe.ok) return;
-  // Is wicked-testing already registered with Claude Code?
-  const listing = spawnSyncSafe("claude", ["plugins", "list"]);
-  if (listing.ok && /(^|\s)wicked-testing(\s|$|@)/.test(listing.stdout || "")) return;
-  if (jsonOut) return; // structured consumers don't want prose guidance
-  console.log("");
-  console.log("\x1b[33mClaude Code note:\x1b[0m the file-copy install above drops skills into");
-  console.log("~/.claude/skills/ but Claude Code only loads skills from registered plugins.");
-  console.log("For full integration, also register the plugin:");
-  console.log("");
-  console.log("  \x1b[36mclaude plugins marketplace add mikeparcewski/wicked-testing\x1b[0m");
-  console.log("  \x1b[36mclaude plugins install wicked-testing\x1b[0m");
-  console.log("");
-  console.log("Other CLIs (Gemini / Codex / Cursor / Kiro) are loaded directly from the");
-  console.log("files copied above — no further action needed on those.");
-}
-
-// Tiny shell-free wrapper so both probes above stay synchronous and never
-// throw on ENOENT. Returns { ok, stdout } — `ok` is false if the binary
-// isn't on PATH or the command exited non-zero.
-function spawnSyncSafe(cmd, args) {
-  try {
-    // shell:true so Windows resolves .cmd / .bat shims on PATH (`claude.cmd`,
-    // etc.). Args are internal and trusted — no user input reaches this call,
-    // so there's no injection surface here.
-    const r = spawnSync(cmd, args, { encoding: "utf8", timeout: 3000, shell: true });
-    if (r.error || r.status !== 0) return { ok: false, stdout: r.stdout || "" };
-    return { ok: true, stdout: r.stdout || "" };
-  } catch {
-    return { ok: false, stdout: "" };
-  }
 }
 
 // --- subcommands -----------------------------------------------------------
@@ -649,15 +604,6 @@ async function cmdInstall({ mode }) {
       legacy_layout_removed: migrated,
     }));
   }
-
-  // Claude-Code-specific guidance: skills dropped into ~/.claude/skills/
-  // without a plugin registration aren't loaded by the Claude Code skill
-  // resolver. Nudge the user toward `claude plugins marketplace add` +
-  // `claude plugins install` when wicked-testing isn't already registered.
-  const claudeInstalled = perTargetReport.find(
-    r => r.target === "claude" && (r.status === "installed" || r.status === "skipped" && r.reason === "already-current")
-  );
-  maybeEmitClaudeCodeGuidance(claudeInstalled);
 
   // Non-zero exit if any target skipped due to a real failure (not just
   // "already installed"). This matches CI expectations — an install script

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-testing",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-testing",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-testing",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "description": "Standalone QE library for AI coding CLIs — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, 3-agent acceptance pipeline, bus+brain optional integration.",
   "keywords": [

--- a/scripts/dev/validate.mjs
+++ b/scripts/dev/validate.mjs
@@ -119,6 +119,18 @@ function checkSkills() {
     for (const k of requiredFields) {
       if (!(k in fm)) err("skills", rel, `missing required frontmatter key: ${k}`);
     }
+    // Frontmatter `name:` MUST be `wicked-testing:<dir>`. When it's just
+    // `<dir>` (unprefixed), Claude Code's skill resolver silently drops
+    // the skill — and if enough skills in the batch are broken, it drops
+    // the whole plugin. This was the v0.3.1 regression caught in dogfood:
+    // 6 of 12 skills had unprefixed names and all 12 became invisible.
+    // Keep this gate strict so we never re-ship that.
+    const expectedName = `wicked-testing:${d}`;
+    if (fm.name && fm.name !== expectedName) {
+      err("skills", rel,
+        `frontmatter name '${fm.name}' must equal '${expectedName}' — ` +
+        `Claude Code's skill resolver requires the plugin-namespaced form.`);
+    }
   }
 }
 

--- a/scripts/dev/validate.mjs
+++ b/scripts/dev/validate.mjs
@@ -126,7 +126,11 @@ function checkSkills() {
     // 6 of 12 skills had unprefixed names and all 12 became invisible.
     // Keep this gate strict so we never re-ship that.
     const expectedName = `wicked-testing:${d}`;
-    if (fm.name && fm.name !== expectedName) {
+    // Strict equality — empty string must also fail here. The required-
+    // fields loop above catches a missing `name:` key; this check catches
+    // the wrong value, including "". If we short-circuited on falsy fm.name
+    // an empty string would bypass the namespace check and ship.
+    if (fm.name !== expectedName) {
       err("skills", rel,
         `frontmatter name '${fm.name}' must equal '${expectedName}' — ` +
         `Claude Code's skill resolver requires the plugin-namespaced form.`);

--- a/skills/acceptance-testing/SKILL.md
+++ b/skills/acceptance-testing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: acceptance-testing
+name: wicked-testing:acceptance-testing
 description: |
   Evidence-gated acceptance testing with three-agent separation of concerns.
   Writer designs test plans, Executor collects artifacts, Reviewer evaluates independently.

--- a/skills/browser-automation/SKILL.md
+++ b/skills/browser-automation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: browser-automation
+name: wicked-testing:browser-automation
 description: |
   Detect and configure browser automation tools (Playwright, Cypress, k6).
   Generates test harness scaffolds and automation code for browser-based scenarios.

--- a/skills/scenario-authoring/SKILL.md
+++ b/skills/scenario-authoring/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: scenario-authoring
+name: wicked-testing:scenario-authoring
 description: |
   Create and edit self-contained test scenario files in the wicked-testing scenario format.
   Writes scenario records to the DomainStore.

--- a/skills/test-oracle/SKILL.md
+++ b/skills/test-oracle/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: test-oracle
+name: wicked-testing:test-oracle
 description: |
   Answer plain-language questions about the testing data domain.
   Routes questions to a fixed parameterized SQL query library — no LLM-generated SQL.

--- a/skills/test-runner/SKILL.md
+++ b/skills/test-runner/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: test-runner
+name: wicked-testing:test-runner
 description: |
   Execute wicked-testing scenario files via the appropriate CLI tool.
   Writes run records and evidence JSON to .wicked-testing/evidence/{run-id}/.

--- a/skills/test-strategy/SKILL.md
+++ b/skills/test-strategy/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: test-strategy
+name: wicked-testing:test-strategy
 description: |
   Plan what and how to test. Generate comprehensive test strategies with coverage analysis,
   risk assessment, and scenario pairing. Writes strategy records to the DomainStore.


### PR DESCRIPTION
v0.3.1 misdiagnosed the "skills don't load in Claude Code" symptom and shipped a `marketplace.json` workaround. The real cause is simpler: **6 of 12 `skills/*/SKILL.md` files had unprefixed `name:` frontmatter** (`name: test-runner` instead of `name: wicked-testing:test-runner`). Claude Code's skill resolver silently rejects skills whose frontmatter namespace doesn't match the plugin — when enough skills in a batch are broken, the whole plugin goes dark.

## The diagnostic

```
$ for d in ~/.claude/skills/wicked-*/; do
    name=$(basename "$d"); fm=$(awk '/^name:/ {print $2; exit}' "$d/SKILL.md")
    echo "$name -> $fm"
  done

wicked-brain-memory         -> wicked-brain:memory           ✓
wicked-brain-ingest         -> wicked-brain:ingest           ✓
...  (23/23 correct)
wicked-testing-plan         -> wicked-testing:plan           ✓
wicked-testing-authoring    -> wicked-testing:authoring      ✓
wicked-testing-update       -> wicked-testing:update         ✓
wicked-testing-execution    -> wicked-testing:execution      ✓
wicked-testing-review       -> wicked-testing:review         ✓
wicked-testing-insight      -> wicked-testing:insight        ✓
wicked-testing-acceptance-testing -> acceptance-testing      ✗  (bare)
wicked-testing-browser-automation -> browser-automation      ✗  (bare)
wicked-testing-scenario-authoring -> scenario-authoring      ✗  (bare)
wicked-testing-test-oracle        -> test-oracle             ✗  (bare)
wicked-testing-test-runner        -> test-runner             ✗  (bare)
wicked-testing-test-strategy      -> test-strategy           ✗  (bare)
```

Same on-disk location as wicked-brain. Same install mechanism. Different frontmatter hygiene.

## Ships

### Fix

- Normalized `name:` frontmatter on all 12 Tier-1 + auxiliary skill files. The 6 bare-name files (`acceptance-testing`, `browser-automation`, `scenario-authoring`, `test-oracle`, `test-runner`, `test-strategy`) are now `wicked-testing:<name>`.
- `scripts/dev/validate.mjs` enforces `name == 'wicked-testing:<dir>'` on every skill. Re-introducing the bare-name form fails `npm test` immediately. Regression tested — the validator emits an explicit error with the required form.

### Reverted

- **README install section** simplified. `npx wicked-testing install` is the preferred path on **every** CLI including Claude Code. The `claude plugins marketplace add` path still works and stays documented as an optional alternative. The v0.3.1 framing of "Claude Code REQUIRES plugin registration" was wrong.
- **`install.mjs` post-install Claude Code guidance removed.** With the frontmatter fix, the guidance is actively misleading. Dropped the `spawnSync`-based `claude` probe helpers too (no caller remaining).

### Kept from v0.3.1

- `.claude-plugin/marketplace.json` — harmless and provides an alternative install path for users who prefer it. `plugins[0].version` bumped to 0.3.2 in this commit.
- Legacy bare-name skill-dir migration in `install.mjs` — still valuable for cleaning up the pre-0.3 layout on upgrade.

## Verified

- `node scripts/dev/validate.mjs` — 0 errors, 0 warnings. Regression-tested: flipping `skills/plan/SKILL.md` back to `name: plan` produces an explicit error `frontmatter name 'plan' must equal 'wicked-testing:plan'`.
- `npm test` clean.
- All 12 repo skills now have correct `wicked-testing:<name>` frontmatter.