### PR TITLE
Release v0.3.3: honor $CLAUDE_CONFIG_DIR + probe alt-config layouts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-testing",
       "source": "./",
       "description": "Standalone QE library for AI coding CLIs \u2014 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, 3-agent acceptance pipeline, optional wicked-bus + wicked-brain integration.",
-      "version": "0.3.2"
+      "version": "0.3.3"
     }
   ],
   "version": "1.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-testing",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Standalone QE library — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, optional wicked-bus + wicked-brain integration.",
   "skills": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to `wicked-testing`. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [SemVer](https://semver.org/).
 
+## [0.3.3] — 2026-04-21
+
+Install-path detection fix. Prior versions hardcoded `~/.claude` (and siblings) as the install target and ignored both `$CLAUDE_CONFIG_DIR` and common alt-config layouts. Users running Claude Code with its config redirected — via `CLAUDE_CONFIG_DIR`, a shared-home setup at `~/alt-configs/.claude`, or an XDG-style `~/.config/claude` — would see `wicked-testing install` complete successfully while silently writing into a path Claude Code never reads. Skills loaded as zero, doctor reported green, users lost hours.
+
+### Fixed
+
+- **`install.mjs` now honors `$CLAUDE_CONFIG_DIR`.** When set, it is authoritative — the installer writes only to that path (trusted, skipping the identity-marker check so first-run setups where the dir exists but is empty still work). This matches Claude Code's own resolution behavior.
+- **Alt-config layouts are now probed automatically.** When `CLAUDE_CONFIG_DIR` is unset, the installer probes `~/.claude`, `~/alt-configs/.claude`, and `~/.config/claude`, installing into each that carries Claude identity markers (`settings.json` / `plugins/` / `projects/`). Multi-config setups stay in sync without manual `--path` juggling.
+- **`--path <dir>` (space-separated) now works.** Previously only `--path=<dir>` was honored; the space form was silently accepted and then dropped, causing installs to fall through to default detection. Fix applies to every flag with a value (`--cli`, `--require`, `--assume-cli`, etc.).
+
+### Added
+
+- **`doctor` surfaces `CLAUDE_CONFIG_DIR` state explicitly.** Shows which path was picked up, from which source (`env:CLAUDE_CONFIG_DIR` / `default` / `alt-configs` / `xdg`), and warns when the env var points at a nonexistent dir or one without Claude identity markers.
+- **`doctor --json` now includes `claude_config_dir` and `detected_targets`** (full `{name, root, source}` records). The legacy `detected_clis` string[] shape is preserved for back-compat.
+- **Help text documents the new behavior** including a `CLAUDE_CONFIG_DIR=~/alt-configs/.claude npx wicked-testing install` example.
+
+### Why this matters
+
+Parallel patches are coming to `wicked-brain` (0.12.1) and `wicked-bus` (1.1.1) for the same bug — all three packages use the same install template and inherited the same flaw.
+
 ## [0.3.2] — 2026-04-21
 
 Real fix for the "skills aren't loading in Claude Code" symptom. The v0.3.1 release misdiagnosed the cause as missing plugin registration and shipped a `marketplace.json` workaround. Turned out to be simpler: **6 of 12 `skills/*/SKILL.md` files had unprefixed `name:` frontmatter** (`name: test-runner` instead of `name: wicked-testing:test-runner`). Claude Code's skill resolver silently rejects skills whose frontmatter namespace doesn't match the plugin — when enough skills in a batch are broken, the whole plugin goes dark.

--- a/install.mjs
+++ b/install.mjs
@@ -48,6 +48,12 @@ const LEGACY_BARE_SKILL_DIRS = [
 // (collides with common GitHub dotfiles, and `gh copilot` does not read
 // that path). Removed until a real integration point exists; tracked in
 // #59.
+//
+// Claude Code is special: its config root is redirectable via
+// $CLAUDE_CONFIG_DIR (used for multi-tenant setups, alt-config layouts
+// like ~/alt-configs/.claude, and corporate-policy home overrides). The
+// single-root claude entry below is only the "default" — resolveClaudeCandidates()
+// expands it into 1..N concrete targets at install time. See #87.
 const CLI_TARGETS = [
   {
     name: "claude",
@@ -103,10 +109,64 @@ const CLI_TARGETS = [
   },
 ];
 
+// Expand the canonical CLI_TARGETS "claude" entry into one or more concrete
+// target objects that reflect the user's actual Claude Code config root.
+//
+// Precedence:
+//   1. $CLAUDE_CONFIG_DIR — authoritative when set. Skip identity-marker
+//      checks (trusted) so `CLAUDE_CONFIG_DIR=/new/path npx wicked-testing`
+//      works even when the dir is freshly created and empty.
+//   2. Otherwise probe ~/.claude plus a small list of alt-config layouts
+//      (~/alt-configs/.claude, ~/.config/claude) — each is filtered by the
+//      normal identity-marker check downstream.
+//
+// Added in 0.3.3 after a user discovered their installs were silently
+// landing in ~/.claude while their real config lived at ~/alt-configs/.claude.
+function buildClaudeTarget(rootDir, source, { trusted = false } = {}) {
+  return {
+    name: "claude",
+    rootDir,
+    dir: join(rootDir, "skills"),
+    agentDir: join(rootDir, "agents"),
+    commandDir: join(rootDir, "commands"),
+    platform: "claude",
+    identityMarkers: ["settings.json", "plugins", "projects"],
+    isolationTier: "hard",
+    source,    // for doctor output ("env:CLAUDE_CONFIG_DIR" / "default" / "alt-configs" / "xdg")
+    trusted,   // skip identity-marker check when true
+  };
+}
+
+function resolveClaudeCandidates() {
+  const envDir = process.env.CLAUDE_CONFIG_DIR;
+  if (envDir && typeof envDir === "string" && envDir.trim()) {
+    const root = resolve(envDir.trim().replace(/^~/, home));
+    return [buildClaudeTarget(root, "env:CLAUDE_CONFIG_DIR", { trusted: true })];
+  }
+  return [
+    buildClaudeTarget(join(home, ".claude"),                 "default"),
+    buildClaudeTarget(join(home, "alt-configs", ".claude"),  "alt-configs"),
+    buildClaudeTarget(join(home, ".config", "claude"),       "xdg"),
+  ];
+}
+
+// Full list of candidate targets with expansion applied. Use this anywhere
+// we'd previously iterate CLI_TARGETS directly (resolveTargets, cmdDoctor).
+function allCandidateTargets() {
+  const out = [];
+  for (const spec of CLI_TARGETS) {
+    if (spec.name === "claude") out.push(...resolveClaudeCandidates());
+    else out.push(spec);
+  }
+  return out;
+}
+
 // A directory that exists but has none of the identity markers is treated
 // as "not really this CLI" — we skip it. Override with --assume-cli=<name>
-// if a power user knows their setup stores markers elsewhere.
+// if a power user knows their setup stores markers elsewhere. Targets
+// flagged `trusted` (explicit --path or $CLAUDE_CONFIG_DIR) bypass this.
 function hasIdentityMarker(target) {
+  if (target.trusted) return true;
   if (!existsSync(target.rootDir)) return false;
   for (const m of target.identityMarkers || []) {
     if (existsSync(join(target.rootDir, m))) return true;
@@ -132,10 +192,20 @@ const subcommand = FLAG_SUBCOMMANDS[first]
   ?? (first && !first.startsWith("-") ? first : "install");
 
 const flags = args.filter(a => a.startsWith("--"));
+// Supports both forms:
+//   --flag=value   (canonical)
+//   --flag value   (common shell muscle-memory; prior versions silently
+//                   treated this as bare `--flag` and dropped the value,
+//                   which is how 0.3.2-era `install --path ~/alt-configs/.claude`
+//                   fell through to default detection. Fixed in 0.3.3.)
 const flagValue = (name) => {
   const f = flags.find(a => a === `--${name}` || a.startsWith(`--${name}=`));
   if (!f) return null;
-  return f.includes("=") ? f.split("=")[1] : true;
+  if (f.includes("=")) return f.split("=")[1];
+  const idx = args.indexOf(f);
+  const next = args[idx + 1];
+  if (next && !next.startsWith("-")) return next;
+  return true;
 };
 
 const force         = !!flagValue("force");
@@ -160,6 +230,8 @@ function resolveTargets() {
       platform: known?.platform ?? dirName,
       identityMarkers: known?.identityMarkers ?? [],
       isolationTier: known?.isolationTier ?? "advisory",
+      source: "path-arg",
+      trusted: true,
     }];
   }
   // Identity-marker detection: presence of `~/.claude/` alone is not enough
@@ -168,10 +240,16 @@ function resolveTargets() {
   // declared in CLI_TARGETS — `settings.json`, `plugins/`, etc. Override
   // with --assume-cli=<name> to force-detect when the host's marker set
   // diverges from our list.
+  //
+  // For claude, allCandidateTargets() expands the canonical spec into the
+  // $CLAUDE_CONFIG_DIR target (if set) or ~/.claude + common alt-config
+  // paths (~/alt-configs/.claude, ~/.config/claude). Each candidate is
+  // filtered individually by the identity-marker check.
   const forceDetect = (assumeCli && typeof assumeCli === "string")
     ? new Set(assumeCli.split(","))
     : new Set();
-  const detected = CLI_TARGETS.filter(t =>
+  const candidates = allCandidateTargets();
+  const detected = candidates.filter(t =>
     forceDetect.has(t.name) || hasIdentityMarker(t)
   );
   if (cliArg && typeof cliArg === "string") {
@@ -335,12 +413,19 @@ Commands:
 
 Options:
   --cli=<list>        Comma-separated CLI names (claude, gemini, codex, cursor, kiro)
-  --path=<dir>        Custom target path (e.g. --path=~/.claude)
+  --path=<dir>        Custom target path (e.g. --path=~/.claude). Also accepts --path <dir>.
   --assume-cli=<list> Force-detect a CLI even if its identity markers are missing
   --force             Overwrite even if versions match
   --require=<spec>    Version spec for 'check' (e.g. 0.2.0, ^0.2.0, ~0.2.1, >=0.2.0)
   --skip-self-test    Skip the SQLite bootstrap self-test (install/update only)
   --json              Machine-readable output where supported
+
+Environment:
+  CLAUDE_CONFIG_DIR   Override Claude Code's config root (authoritative when set).
+                      Install will target ONLY this path for the claude CLI. When
+                      unset, wicked-testing probes ~/.claude, ~/alt-configs/.claude,
+                      and ~/.config/claude, and installs into each that has Claude
+                      identity markers (settings.json / plugins/ / projects/).
 
 Examples:
   npx wicked-testing install
@@ -349,6 +434,7 @@ Examples:
   npx wicked-testing status --json
   npx wicked-testing uninstall --cli=claude
   npx wicked-testing doctor
+  CLAUDE_CONFIG_DIR=~/alt-configs/.claude npx wicked-testing install
 `);
 }
 
@@ -393,10 +479,31 @@ async function cmdDoctor() {
     ? { name: "node",          status: "ok",   message: process.versions.node }
     : { name: "node",          status: "fail", message: `${process.versions.node} — need >= 18`, fix: "install Node 18+" });
 
-  // AI CLI detection
-  const detected = CLI_TARGETS.filter(t => hasIdentityMarker(t));
+  // $CLAUDE_CONFIG_DIR awareness — surface what we picked up (or didn't)
+  // so users debugging "why didn't my install take" can see whether we
+  // honored the env var. Added in 0.3.3 after installs silently hit
+  // ~/.claude while the user's real config lived at ~/alt-configs/.claude.
+  const envDir = process.env.CLAUDE_CONFIG_DIR;
+  if (envDir && envDir.trim()) {
+    const resolvedEnv = resolve(envDir.trim().replace(/^~/, home));
+    if (!existsSync(resolvedEnv)) {
+      checks.push({ name: "CLAUDE_CONFIG_DIR", status: "warn", message: `set to ${resolvedEnv} but the directory does not exist`, fix: "create the directory or unset CLAUDE_CONFIG_DIR" });
+    } else {
+      const hasMarkers = ["settings.json", "plugins", "projects"].some(m => existsSync(join(resolvedEnv, m)));
+      checks.push(hasMarkers
+        ? { name: "CLAUDE_CONFIG_DIR", status: "ok",   message: resolvedEnv }
+        : { name: "CLAUDE_CONFIG_DIR", status: "warn", message: `${resolvedEnv} exists but has no Claude identity markers (settings.json / plugins/ / projects/)`, fix: "verify Claude Code is actually configured at this path" });
+    }
+  }
+
+  // AI CLI detection — use allCandidateTargets() so alt-config Claude
+  // layouts show up here instead of being invisible to doctor.
+  const detected = allCandidateTargets().filter(t => hasIdentityMarker(t));
   checks.push(detected.length > 0
-    ? { name: "cli-detection", status: "ok",   message: detected.map(d => `${d.name} (${d.isolationTier})`).join(", ") }
+    ? { name: "cli-detection", status: "ok",   message: detected.map(d => {
+        const suffix = d.source && d.source !== "default" ? ` @ ${d.rootDir} [${d.source}]` : "";
+        return `${d.name}${suffix} (${d.isolationTier})`;
+      }).join(", ") }
     : { name: "cli-detection", status: "fail", message: "no AI CLIs detected in home directory", fix: "install Claude Code / Gemini / Codex / Cursor / Kiro, or use --path=<dir>" });
 
   // better-sqlite3 native module
@@ -406,13 +513,19 @@ async function cmdDoctor() {
     ? { name: "better-sqlite3", status: "ok",   message: "loadable" }
     : { name: "better-sqlite3", status: "fail", message: "native module failed to load", fix: "run `npm rebuild better-sqlite3` or reinstall Node 18+ on a supported platform" });
 
-  // Per-target install-marker integrity
+  // Per-target install-marker integrity. Disambiguate by source when the
+  // same CLI name has multiple roots (e.g., two claude targets at
+  // ~/.claude and ~/alt-configs/.claude).
+  const claudeTargetCount = detected.filter(t => t.name === "claude").length;
   for (const t of detected) {
+    const suffix = (t.name === "claude" && claudeTargetCount > 1 && t.source)
+      ? `[${t.source}]` : "";
+    const checkName = `install:${t.name}${suffix}`;
     const installed = installedVersion(t);
     if (installed === null) {
-      checks.push({ name: `install:${t.name}`, status: "warn", message: "not installed yet", fix: `run \`npx wicked-testing install --cli=${t.name}\`` });
+      checks.push({ name: checkName, status: "warn", message: `not installed yet at ${t.rootDir}`, fix: `run \`npx wicked-testing install --cli=${t.name}\`` });
     } else if (installed !== VERSION) {
-      checks.push({ name: `install:${t.name}`, status: "warn", message: `installed ${installed}, code is ${VERSION}`, fix: `run \`npx wicked-testing update --cli=${t.name}\`` });
+      checks.push({ name: checkName, status: "warn", message: `installed ${installed} at ${t.rootDir}, code is ${VERSION}`, fix: `run \`npx wicked-testing update --cli=${t.name}\`` });
     } else {
       // Spot-check: a few expected agent files are present and non-empty.
       const expected = ["wicked-testing-acceptance-test-reviewer.md", "wicked-testing-test-oracle.md"];
@@ -422,8 +535,8 @@ async function cmdDoctor() {
         try { return statSync(p).size === 0; } catch { return true; }
       });
       checks.push(missing.length === 0
-        ? { name: `install:${t.name}`, status: "ok",   message: `${VERSION} integrity verified (${t.isolationTier})` }
-        : { name: `install:${t.name}`, status: "fail", message: `missing/empty agent files: ${missing.join(", ")}`, fix: `run \`npx wicked-testing install --force --cli=${t.name}\`` });
+        ? { name: checkName, status: "ok",   message: `${VERSION} integrity verified (${t.isolationTier})` }
+        : { name: checkName, status: "fail", message: `missing/empty agent files: ${missing.join(", ")}`, fix: `run \`npx wicked-testing install --force --cli=${t.name}\`` });
     }
   }
 
@@ -465,7 +578,11 @@ async function cmdDoctor() {
   if (jsonOut) {
     console.log(JSON.stringify({
       node: process.versions.node,
+      claude_config_dir: process.env.CLAUDE_CONFIG_DIR ?? null,
+      // Preserve the 0.3.2 shape (string[]) for back-compat. Rich info
+      // (rootDir, source) is under detected_targets.
       detected_clis: detected.map(d => d.name),
+      detected_targets: detected.map(d => ({ name: d.name, root: d.rootDir, source: d.source ?? "default" })),
       sqlite_ok: sqliteOk,
       checks,
       healthy: fails.length === 0,

--- a/install.mjs
+++ b/install.mjs
@@ -201,11 +201,21 @@ const flags = args.filter(a => a.startsWith("--"));
 const flagValue = (name) => {
   const f = flags.find(a => a === `--${name}` || a.startsWith(`--${name}=`));
   if (!f) return null;
-  if (f.includes("=")) return f.split("=")[1];
-  const idx = args.indexOf(f);
-  const next = args[idx + 1];
-  if (next && !next.startsWith("-")) return next;
-  return true;
+  let val;
+  if (f.includes("=")) {
+    val = f.split("=")[1];
+  } else {
+    const idx = args.indexOf(f);
+    const next = args[idx + 1];
+    val = (next && !next.startsWith("-")) ? next : true;
+  }
+  // String boolean coercion: `--force=false` should evaluate to boolean
+  // false, not the truthy string "false". Since callers use `!!flagValue()`
+  // the truthy-string case was silently flipping intent. Kept narrow: only
+  // literal "true" / "false" are coerced; other string values pass through.
+  if (val === "false") return false;
+  if (val === "true")  return true;
+  return val;
 };
 
 const force         = !!flagValue("force");
@@ -483,16 +493,24 @@ async function cmdDoctor() {
   // so users debugging "why didn't my install take" can see whether we
   // honored the env var. Added in 0.3.3 after installs silently hit
   // ~/.claude while the user's real config lived at ~/alt-configs/.claude.
-  const envDir = process.env.CLAUDE_CONFIG_DIR;
-  if (envDir && envDir.trim()) {
-    const resolvedEnv = resolve(envDir.trim().replace(/^~/, home));
-    if (!existsSync(resolvedEnv)) {
-      checks.push({ name: "CLAUDE_CONFIG_DIR", status: "warn", message: `set to ${resolvedEnv} but the directory does not exist`, fix: "create the directory or unset CLAUDE_CONFIG_DIR" });
+  //
+  // Reuse resolveClaudeCandidates() so the marker list and path rules stay
+  // canonical — any drift between installer and doctor would be a source
+  // of confusing "installer wrote here but doctor says that" bugs.
+  const envTarget = resolveClaudeCandidates().find(t => t.source === "env:CLAUDE_CONFIG_DIR");
+  if (envTarget) {
+    const root = envTarget.rootDir;
+    if (!existsSync(root)) {
+      checks.push({ name: "CLAUDE_CONFIG_DIR", status: "warn", message: `set to ${root} but the directory does not exist`, fix: "create the directory or unset CLAUDE_CONFIG_DIR" });
     } else {
-      const hasMarkers = ["settings.json", "plugins", "projects"].some(m => existsSync(join(resolvedEnv, m)));
+      // Identity markers are trusted-skipped at install time so empty
+      // freshly-created dirs work. In doctor we want to actually verify
+      // them so we catch the "env var points at the wrong place" case.
+      const markers = envTarget.identityMarkers || [];
+      const hasMarkers = markers.some(m => existsSync(join(root, m)));
       checks.push(hasMarkers
-        ? { name: "CLAUDE_CONFIG_DIR", status: "ok",   message: resolvedEnv }
-        : { name: "CLAUDE_CONFIG_DIR", status: "warn", message: `${resolvedEnv} exists but has no Claude identity markers (settings.json / plugins/ / projects/)`, fix: "verify Claude Code is actually configured at this path" });
+        ? { name: "CLAUDE_CONFIG_DIR", status: "ok",   message: root }
+        : { name: "CLAUDE_CONFIG_DIR", status: "warn", message: `${root} exists but has no Claude identity markers (${markers.join(" / ")})`, fix: "verify Claude Code is actually configured at this path" });
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-testing",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-testing",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-testing",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "description": "Standalone QE library for AI coding CLIs — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, 3-agent acceptance pipeline, bus+brain optional integration.",
   "keywords": [


### PR DESCRIPTION
## Summary

- Fixes a silent install-to-wrong-path bug: `install.mjs` hardcoded `~/.claude` and ignored both `$CLAUDE_CONFIG_DIR` and common alt-config layouts. Users with redirected Claude Code config roots (shared-home, multi-tenant, `~/alt-configs/.claude`, XDG-ish `~/.config/claude`) saw installs complete successfully while writing to a path Claude Code never reads — skills loaded as zero, doctor reported green.
- `$CLAUDE_CONFIG_DIR` is now authoritative when set (trusted target — skips identity-marker check so freshly-created dirs work on first run).
- When unset, `install.mjs` probes `~/.claude`, `~/alt-configs/.claude`, `~/.config/claude` and installs into each that has Claude identity markers (`settings.json` / `plugins/` / `projects/`).
- Also fixes space-separated `--path <dir>` (prior versions silently dropped the value and fell through to default detection). Applies to every flag with a value.
- `doctor` now surfaces `$CLAUDE_CONFIG_DIR` state explicitly, shows which Claude root was picked + source (`env:CLAUDE_CONFIG_DIR` / `default` / `alt-configs` / `xdg`), disambiguates multi-root `install:claude` checks, and adds `claude_config_dir` + `detected_targets` to `--json`. Legacy `detected_clis` shape preserved for back-compat.

## Why

Hit in practice: the user has `CLAUDE_CONFIG_DIR=~/alt-configs/.claude` set. v0.3.2's `install.mjs` ignored the env var and wrote to `~/.claude` — where Claude Code was not looking. `npx wicked-testing install --path ~/alt-configs/.claude` (space-separated) also didn't work because the arg parser only accepted `--path=<dir>`. The install appeared to succeed but the skills were invisible. This PR makes the installer match where Claude Code actually resolves config from, and fixes the CLI ergonomics that masked the symptom.

Parallel patches to follow for `wicked-brain` (0.12.1) and `wicked-bus` (1.1.1) — same install template, same flaw.

## Test plan

- [x] `npm test` passes (validator + plugin.json sync check)
- [x] `node install.mjs doctor` with `CLAUDE_CONFIG_DIR` set: shows single claude target at the env-var path, tagged `[env:CLAUDE_CONFIG_DIR]`
- [x] `CLAUDE_CONFIG_DIR="" node install.mjs doctor`: probes all fallback paths; my machine has two (default + alt-configs) and both show with distinct `[source]` tags and disambiguated `install:claude[default]` / `install:claude[alt-configs]` check names
- [x] `node install.mjs status --path /tmp/fake-claude` (space-separated) produces identical output to `--path=/tmp/fake-claude`
- [x] `node install.mjs install --force --cli=claude`: lands at `$CLAUDE_CONFIG_DIR` path with 0.3.3 marker
- [x] `doctor --json` includes `claude_config_dir`, `detected_targets` with `{name, root, source}` records; `detected_clis` stays as `string[]` for back-compat
- [ ] CI green on GitHub Actions
- [ ] gemini-code-assist review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)