### PR TITLE
chore: require Node >=20 to match better-sqlite3@12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "wicked-testing": "install.mjs"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/base64-js": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "evals:summary": "node scripts/dev/evals-summary.mjs"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }


### PR DESCRIPTION
`better-sqlite3@^12` is a runtime **dependency** and requires Node ≥ 20, but
`engines.node` still declared `>=18.0.0` — so a consumer on Node 18 couldn't
actually run this package.

- `engines.node`: `>=18.0.0` → `>=20.0.0` (+ lockfile mirror synced).
- No dependency, version, or source changes.
- CI already runs on `lts/*` (≥ 20), so this only makes the declaration honest.

Mirrors the fix applied to wicked-bus and wicked-brain. Consumers on Node 18–19
will now see an `EBADENGINE` warning (intentional — Node 18 is EOL,
better-sqlite3@12 needs ≥ 20).

> Note: I kept the lockfile diff to the `engines` line only. `npm install`
> revealed pre-existing drift in `package-lock.json` (it still records
> `version 0.4.0`, lacks the `wicked-testing-install` bin, and carries a stale
> `hasInstallScript`) — left out of this PR so the engines bump stays focused.
> Worth a separate `npm install` reconciliation commit.

`npm test` (validate + version-sync) passes on Node 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)