### PR TITLE
chore: reconcile package-lock with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "wicked-testing",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-testing",
-      "version": "0.4.0",
-      "hasInstallScript": true,
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.0.0"
       },
       "bin": {
-        "wicked-testing": "install.mjs"
+        "wicked-testing": "install.mjs",
+        "wicked-testing-install": "install.mjs"
       },
       "engines": {
         "node": ">=20.0.0"


### PR DESCRIPTION
Follow-up to #90. Surfaced while bumping `engines`: `package-lock.json` had
drifted from `package.json`.

`npm install` reconciles three stale fields (lockfile-only, no `package.json`
change):
- root `version`: `0.4.0` → `0.4.1` (matches package.json)
- `bin`: adds the `wicked-testing-install` alias
- removes stale `hasInstallScript: true` (package.json has no pre/install/post-install script)

## Scope / safety
- **No dependency version churn** — `better-sqlite3` and all transitive deps unchanged.
- **No source or package.json changes.**
- `npm ci --dry-run` now reports the lockfile **in sync** (it was out-of-sync before — a latent release-time `npm ci` failure).
- `npm test` (validate + version-sync) passes on Node 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)