### PR TITLE
chore(release): 0.4.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-testing",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Standalone QE library — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, optional wicked-bus + wicked-brain integration.",
   "skills": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-testing",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-testing",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-testing",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "description": "Standalone QE library for AI coding CLIs — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, 3-agent acceptance pipeline, bus+brain optional integration.",
   "keywords": [


### PR DESCRIPTION
Version bump to **0.4.2** ahead of tagging `v0.4.2`.

wicked-testing's `release.yml` sets the version only transiently for `npm publish`
and has **no** package.json catch-up job (unlike wicked-bus / wicked-brain), so
`main` must be bumped manually to match the tag.

- `package.json` + `package-lock.json` + `.claude-plugin/plugin.json` → `0.4.2`
  (kept in lockstep via `sync-plugin-version`, so `npm test`'s drift check passes).
- Releases what landed since v0.4.1: `engines.node >=20` (#90) and the
  package-lock reconciliation (#91).

After merge I'll tag `v0.4.2` to trigger the publish pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)