### PR TITLE
ci: adopt shared wicked-ci workflows + fix version-file drift

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "wicked-testing",
       "source": "./",
-      "description": "Standalone QE library for AI coding CLIs \u2014 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, 3-agent acceptance pipeline, optional wicked-bus + wicked-brain integration.",
-      "version": "0.4.0"
+      "description": "Standalone QE library for AI coding CLIs — 5-core testing surface (plan/authoring/execution/review/insight), SQLite ledger with fixed-SQL oracle, 3-agent acceptance pipeline, optional wicked-bus + wicked-brain integration.",
+      "version": "0.4.2"
     }
   ],
   "version": "1.0.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,5 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-      - run: npm install
-      - run: npm test
+  ci:
+    uses: mikeparcewski/wicked-ci/.github/workflows/node-ci.yml@0382b46d00d772c09911f9d00021e0172eb9abe4 # v1.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,72 +11,8 @@ permissions:
   id-token: write
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-      - run: npm install
-      - run: npm test
-
-  publish-npm:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-          registry-url: https://registry.npmjs.org
-
-      - name: Set version from tag
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          npm version "$VERSION" --no-git-tag-version --allow-same-version
-
-      - name: Publish to npm (trusted publisher + provenance)
-        run: npm publish --access public --provenance
-
-  publish-github-packages:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-          registry-url: https://npm.pkg.github.com
-          scope: '@mikeparcewski'
-
-      - name: Set version from tag
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          npm version "$VERSION" --no-git-tag-version --allow-same-version
-
-      - name: Publish to GitHub Packages
-        run: |
-          npm pkg set name='@mikeparcewski/wicked-testing'
-          npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  github-release:
-    needs: publish-npm
-    if: always() && needs.publish-npm.result == 'success'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release:
+    uses: mikeparcewski/wicked-ci/.github/workflows/node-release.yml@0382b46d00d772c09911f9d00021e0172eb9abe4 # v1.1.0
+    with:
+      package_name: wicked-testing
+    secrets: inherit

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>mikeparcewski/wicked-ci#v1.1.0"
+  ]
+}

--- a/scripts/dev/sync-plugin-version.mjs
+++ b/scripts/dev/sync-plugin-version.mjs
@@ -33,6 +33,7 @@ function tierOf(absPath) {
 
 const pkgPath    = join(REPO, "package.json");
 const pluginPath = join(REPO, ".claude-plugin", "plugin.json");
+const marketplacePath = join(REPO, ".claude-plugin", "marketplace.json");
 const argv = process.argv.slice(2);
 const checkOnly = argv.includes("--check");
 const quiet     = argv.includes("--quiet");
@@ -46,6 +47,22 @@ try {
 } catch (err) {
   console.error(`sync-plugin-version: could not read inputs — ${err.message}`);
   process.exit(2);
+}
+
+// marketplace.json carries its own copy of the plugin version in plugins[].
+// It is NOT derived from package.json the way plugin.json is, so it silently
+// drifted (0.4.0 vs a 0.4.2 plugin.json) until this was wired in. Optional —
+// tolerate its absence so the script stays reusable for siblings without one.
+let marketplace = null;
+let mpEntry = null;
+if (existsSync(marketplacePath)) {
+  try {
+    marketplace = JSON.parse(readFileSync(marketplacePath, "utf8"));
+  } catch (err) {
+    console.error(`sync-plugin-version: could not read marketplace.json — ${err.message}`);
+    process.exit(2);
+  }
+  mpEntry = (marketplace.plugins ?? []).find(p => p.name === plugin.name) ?? null;
 }
 
 // --- Derive the canonical manifest shape from disk -------------------------
@@ -113,6 +130,8 @@ if (plugin.version !== desired.version)       drifts.push(`version: ${plugin.ver
 if (!jsonEqual(plugin.skills,   desired.skills))   drifts.push(`skills (${plugin.skills?.length ?? 0} -> ${desired.skills.length})`);
 if (!jsonEqual(plugin.agents,   desired.agents))   drifts.push(`agents (${plugin.agents?.length ?? 0} -> ${desired.agents.length})`);
 if (!jsonEqual(plugin.commands, desired.commands)) drifts.push(`commands (${plugin.commands?.length ?? 0} -> ${desired.commands.length})`);
+if (mpEntry && mpEntry.version !== desired.version)
+  drifts.push(`marketplace.json entry: ${mpEntry.version} -> ${desired.version}`);
 
 if (drifts.length === 0) {
   log(`plugin.json in sync (v${pkg.version}, ${desired.skills.length} skills, ${desired.agents.length} agents, ${desired.commands.length} commands)`);
@@ -130,7 +149,15 @@ if (checkOnly) {
 
 const merged = { ...plugin, ...desired };
 writeFileSync(pluginPath, JSON.stringify(merged, null, 2) + "\n");
-log(`plugin.json updated:`);
+
+// Keep the marketplace plugin entry's version in lockstep too. Only the
+// version is derived — descriptions/source are author-maintained.
+if (mpEntry && mpEntry.version !== desired.version) {
+  mpEntry.version = desired.version;
+  writeFileSync(marketplacePath, JSON.stringify(marketplace, null, 2) + "\n");
+}
+
+log(`manifest updated:`);
 for (const d of drifts) log(`  - ${d}`);
 
 emitBusEvent("wicked.contract.published", {


### PR DESCRIPTION
Cutover to `wicked-ci@0382b46 # v1.1.0`, keeps `evals.yml`. Also fixes Q1 drift: marketplace.json 0.4.0→0.4.2 and the sync guard now covers marketplace.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)