### PR TITLE
feat(verdict): add CONDITIONAL to enum + equivalence/baseline-match facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@ All notable changes to `wicked-testing`. Format loosely follows
   `invalid verdict.value 'CONDITIONAL'`. Added to the enum, the prejudicial-
   content matcher, `docs/EVIDENCE.md`, and the acceptance-skill
   `VERDICT_TO_STATUS` map (`CONDITIONAL → partial`). Migration `002` adds a
-  `CHECK` constraint to `verdicts.verdict` covering the full enum so an
-  out-of-enum value now fails loudly at write time.
+  `CHECK` constraint to `verdicts.verdict` covering the full enum, and
+  `DomainStore.create()` now validates the verdict against the enum (the shared
+  `VERDICT_VALUES` source of truth) *before* the dual-write — so an out-of-enum
+  value fails loudly and atomically (throws `ERR_INVALID_VERDICT`, nothing
+  written to either store) instead of silently diverging the canonical JSON
+  from the SQLite index.
 
 ### Added
 - **Equivalence / baseline-match as a first-class verdict facet.** Optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to `wicked-testing`. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **`CONDITIONAL` is now a legal verdict value (latent contract bug).** Four
+  Tier-2 agents (`release-readiness`, `security`, `ai-feature`,
+  `test-code-quality`) already emit `CONDITIONAL`, but it was absent from the
+  manifest verdict enum (`schemas/evidence.json`, `lib/manifest.mjs`
+  `validateShape`) — so the first manifest built off such a run threw
+  `invalid verdict.value 'CONDITIONAL'`. Added to the enum, the prejudicial-
+  content matcher, `docs/EVIDENCE.md`, and the acceptance-skill
+  `VERDICT_TO_STATUS` map (`CONDITIONAL → partial`). Migration `002` adds a
+  `CHECK` constraint to `verdicts.verdict` covering the full enum so an
+  out-of-enum value now fails loudly at write time.
+
+### Added
+- **Equivalence / baseline-match as a first-class verdict facet.** Optional
+  `verdict.equivalence` block `{ baseline_ref, baseline_sha, method, diff_count,
+  tolerance, matched }` in the evidence schema (manifest minor bump
+  `1.0.0 → 1.1.0`); an `EQUIVALENT_TO_BASELINE` reviewer operator; scenario
+  `assertions[].baseline` / `method` / `tolerance` support + `equivalence`
+  category; a nullable `verdicts.equivalence_json` column (migration `002`); and
+  the fixed oracle query `baseline_matches_for_scenario`. All optional and
+  backward-compatible — existing rows, readers, and manifests are unaffected.
+- **Versioned migration `002_verdict_check_and_equivalence.sql`** — the first
+  follow-on migration; applies in numeric order via `lib/migrate.mjs` on both
+  fresh and pre-existing v1 databases. `SCHEMA_VERSION` bumped `1 → 2`.
+
 ## [0.4.1] — 2026-06-10
 
 Docs-truth patch — no behavior change.

--- a/DATA-DOMAIN.md
+++ b/DATA-DOMAIN.md
@@ -91,12 +91,13 @@ The Node.js implementation diverges from wicked-garden's `_domain_store.py` in t
 
 ## Oracle Query Library
 
-The `test-oracle` skill uses `lib/oracle-queries.mjs` — a fixed library of 12 named parameterized queries:
+The `test-oracle` skill uses `lib/oracle-queries.mjs` — a fixed library of 13 named parameterized queries:
 
 - `scenarios_for_project`, `last_verdict_for_scenario`, `runs_by_status`
 - `failed_runs_since`, `tasks_by_status`, `tasks_for_project`
 - `current_strategy_for_project`, `recent_runs`, `verdicts_since`
 - `row_counts`, `schema_version`, `most_recent_project`
+- `baseline_matches_for_scenario` (equivalence / baseline-match facts)
 
 No LLM-generated SQL. No ad-hoc queries. Every query is auditable by code review.
 

--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -111,8 +111,8 @@ Created by `/wicked-testing:setup`. Records the project name and detected CLI ca
 
 Singleton-per-process DomainStore. On construction:
 1. Opens/creates `.wicked-testing/wicked-testing.db`
-2. Applies `lib/schema.sql` (idempotent `CREATE TABLE IF NOT EXISTS`)
-3. Checks schema version against `SCHEMA_VERSION = 1`
+2. Applies pending migrations from `lib/migrations/NNN_*.sql` in numeric order (`lib/migrate.mjs`)
+3. Checks schema version against `SCHEMA_VERSION = 2`
 4. Prepares INSERT statements for all 7 tables
 5. Enables WAL mode for concurrent readers
 

--- a/SCENARIO-FORMAT.md
+++ b/SCENARIO-FORMAT.md
@@ -12,7 +12,7 @@ name: scenario-name          # Required. Unique identifier (slug format)
 description: |               # Required. What this scenario tests
   One or more lines describing the scenario's purpose.
 version: "1.0"               # Required. Scenario format version
-category: api                # Required. api|browser|perf|infra|security|a11y|cli
+category: api                # Required. api|browser|perf|infra|security|a11y|cli|equivalence
 tags: [smoke, auth]          # Optional. List of tags for filtering
 tools:
   required: [curl]           # Required CLIs — scenario SKIPs if missing
@@ -23,6 +23,11 @@ assertions:                  # Required. High-level acceptance criteria
     description: Response status is 200
   - id: A2
     description: Response body contains expected fields
+  - id: A3                   # Optional equivalence assertion (baseline-match)
+    description: Output matches the captured baseline
+    baseline: tests/baselines/cart.json   # Optional. Path to the captured baseline artifact
+    method: golden-master                 # Optional. golden-master|contract|reconciliation|perceptual
+    tolerance: 0                          # Optional. Allowed diff count (default 0)
 ---
 ```
 
@@ -39,6 +44,9 @@ assertions:                  # Required. High-level acceptance criteria
 | `tools.optional` | No | CLIs used if present; degraded gracefully if absent |
 | `timeout` | No | Per-step timeout in seconds (default: 120) |
 | `assertions` | Yes | Array of high-level acceptance criteria (id + description) |
+| `assertions[].baseline` | No | Path to a captured baseline artifact — makes the assertion an equivalence (baseline-match) check |
+| `assertions[].method` | No | Equivalence method when `baseline` is set: `golden-master`, `contract`, `reconciliation`, or `perceptual` (default `golden-master`) |
+| `assertions[].tolerance` | No | Allowed diff count for an equivalence assertion (default `0` — exact match) |
 
 ## Category Values
 
@@ -51,6 +59,7 @@ assertions:                  # Required. High-level acceptance criteria
 | `security` | semgrep | SAST, code security patterns |
 | `a11y` | pa11y | WCAG compliance, accessibility violations |
 | `cli` | bash | CLI command behavior, exit codes |
+| `equivalence` | diff, jq, pixelmatch | Baseline-match: output reproduces a captured baseline within tolerance (golden-master / contract / reconciliation / perceptual) |
 
 ## Body Format
 
@@ -248,7 +257,7 @@ import('./lib/domain-store.mjs').then(({ DomainStore }) => {
 
 **Expect**: Exit code 0, valid JSON with `counts` object containing table names
 
-### Step 2: Schema version is 1 (node)
+### Step 2: Schema version is at least 1 (node)
 
 ```bash
 node -e "
@@ -256,13 +265,13 @@ import('./lib/domain-store.mjs').then(({ DomainStore }) => {
   const store = new DomainStore('.wicked-testing');
   const version = store.schemaVersion();
   console.log('Schema version:', version);
-  if (version !== 1) { console.error('FAIL: expected version 1, got', version); process.exit(1); }
+  if (!(version >= 1)) { console.error('FAIL: expected version >= 1, got', version); process.exit(1); }
   store.close();
 }).catch(e => { console.error(e.message); process.exit(1); });
 "
 ```
 
-**Expect**: Exit code 0, "Schema version: 1"
+**Expect**: Exit code 0, "Schema version:" line with a value >= 1 (currently 2)
 ```
 
 ## Validation Rules

--- a/agents/acceptance-test-reviewer.md
+++ b/agents/acceptance-test-reviewer.md
@@ -108,6 +108,7 @@ For each assertion in the test plan:
 | `NOT_EMPTY` | Non-whitespace content present. |
 | `JSON_PATH` | Parse JSON, navigate path, check value. |
 | `COUNT_GTE` | Count >= threshold. |
+| `EQUIVALENT_TO_BASELINE` | Compare a fresh artifact against a captured baseline artifact (both paths supplied in the test plan). Count differences with the assertion's `method` (`golden-master` byte/field diff, `contract` schema diff, `reconciliation` row/field diff, `perceptual` pixel diff). PASS iff `diff_count <= tolerance` (default tolerance 0). Record the result as a `verdict.equivalence` facet `{ baseline_ref, baseline_sha, method, diff_count, tolerance, matched }`. A missing baseline is `INCONCLUSIVE` (cannot evaluate), never PASS. |
 | `HUMAN_REVIEW` | Flag for human review with context. |
 
 For each assertion:
@@ -118,6 +119,28 @@ For each assertion:
 - **Verdict**: PASS|FAIL|INCONCLUSIVE
 - **Reasoning**: {why this verdict}
 ```
+
+#### Baseline-match (`EQUIVALENT_TO_BASELINE`)
+
+When an assertion declares a `baseline:` and `method:`, you are rendering an
+**equivalence verdict** — "did this output reproduce the captured baseline?".
+A green run is *not* sufficient evidence of a faithful reproduction; the
+baseline-match is the verdict-of-record. Report it as a typed facet so it is
+queryable from the ledger (oracle query `baseline_matches_for_scenario`):
+
+```markdown
+#### Assertion: `cart-response.json` EQUIVALENT_TO_BASELINE `tests/baselines/cart.json` (golden-master)
+- **Baseline examined**: tests/baselines/cart.json (sha256 7d8f…)
+- **Diff count**: 0 (tolerance: 0)
+- **Verdict**: PASS — output matched the baseline within tolerance
+- **equivalence**: { "baseline_ref": "tests/baselines/cart.json", "baseline_sha": "7d8f…",
+  "method": "golden-master", "diff_count": 0, "tolerance": 0, "matched": true }
+```
+
+The skill carries this `equivalence` object onto the verdict it writes (it
+lands in `verdict.equivalence` in the manifest and the `equivalence_json`
+column in the ledger). If the baseline artifact is absent, this is
+`INCONCLUSIVE` (`EVIDENCE_MISSING`), never PASS.
 
 ### 4. Check Specification Notes
 

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -45,7 +45,7 @@ Formal JSON Schema: [`schemas/evidence.json`](../schemas/evidence.json)
   "duration_ms": 3217,
   "status":  "failed",              // passed | failed | partial | inconclusive | errored | skipped
   "verdict": {
-    "value":     "FAIL",            // PASS | FAIL | PARTIAL | INCONCLUSIVE | N-A | SKIP
+    "value":     "FAIL",            // PASS | FAIL | PARTIAL | CONDITIONAL | INCONCLUSIVE | N-A | SKIP
     "reviewer":  "wicked-testing:acceptance-test-reviewer",
     "reason":    "Step 3 assertion: expected 401, got 200",
     "recorded_at": "2026-04-20T14:03:16.103Z"
@@ -104,7 +104,7 @@ Formal JSON Schema: [`schemas/evidence.json`](../schemas/evidence.json)
 | `finished_at`         | yes      | ISO 8601 UTC with `Z`.                               |
 | `duration_ms`         | yes      | Integer milliseconds.                                |
 | `status`              | yes      | `passed | failed | partial | inconclusive | errored | skipped`. |
-| `verdict.value`       | yes      | `PASS | FAIL | PARTIAL | INCONCLUSIVE | N-A | SKIP`.  |
+| `verdict.value`       | yes      | `PASS | FAIL | PARTIAL | CONDITIONAL | INCONCLUSIVE | N-A | SKIP`.  |
 | `verdict.reviewer`    | yes      | Agent subagent_type that judged.                     |
 | `verdict.reason`      | when FAIL/N-A/SKIP | Free text. ≤ 500 chars recommended.        |
 | `environment.*`       | yes      | Best-effort capture at run start.                    |

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -107,6 +107,7 @@ Formal JSON Schema: [`schemas/evidence.json`](../schemas/evidence.json)
 | `verdict.value`       | yes      | `PASS | FAIL | PARTIAL | CONDITIONAL | INCONCLUSIVE | N-A | SKIP`.  |
 | `verdict.reviewer`    | yes      | Agent subagent_type that judged.                     |
 | `verdict.reason`      | when FAIL/N-A/SKIP | Free text. ≤ 500 chars recommended.        |
+| `verdict.equivalence` | no       | Optional baseline-match facet. When both `diff_count` and `tolerance` are present, the producer guarantees the invariant `matched === (diff_count <= tolerance)`; a contradictory facet is dropped rather than recorded. |
 | `environment.*`       | yes      | Best-effort capture at run start.                    |
 | `artifacts[]`         | yes      | Empty array allowed for `skipped`.                   |
 | `artifacts[].kind`    | yes      | See table below.                                     |

--- a/lib/context-md-validator.mjs
+++ b/lib/context-md-validator.mjs
@@ -25,9 +25,9 @@ import { writeFileSync, existsSync } from "node:fs";
 // failure messages can be actionable.
 const PREJUDICIAL_PATTERNS = [
   { name: "verdict_assignment",
-    re: /\bverdict\s*[:=]\s*["']?(PASS|FAIL|INCONCLUSIVE|N-A|SKIP)\b/i },
+    re: /\bverdict\s*[:=]\s*["']?(PASS|FAIL|PARTIAL|CONDITIONAL|INCONCLUSIVE|N-A|SKIP)\b/i },
   { name: "standalone_verdict_line",
-    re: /^\s*(verdict|status|outcome)\s*[:=]\s*["']?(PASS|FAIL|INCONCLUSIVE|N-A|SKIP)\b/im },
+    re: /^\s*(verdict|status|outcome)\s*[:=]\s*["']?(PASS|FAIL|PARTIAL|CONDITIONAL|INCONCLUSIVE|N-A|SKIP)\b/im },
   { name: "run_id_reference",
     re: /\brun_id\s*[:=]/i },
   { name: "historical_reference",

--- a/lib/domain-store.mjs
+++ b/lib/domain-store.mjs
@@ -33,6 +33,17 @@ import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { emitBusEvent, domainEventToBusEvent } from "./bus-emit.mjs";
 import { applyMigrations } from "./migrate.mjs";
+import { VERDICT_VALUES } from "./manifest.mjs";
+
+// Pre-write verdict guard set. Built once from the single source of truth
+// (lib/manifest.mjs VERDICT_VALUES — the same list validateShape and the
+// schema use). The verdicts.verdict CHECK constraint (migration 002) enforces
+// this at the index, but create() writes canonical JSON FIRST; without this
+// application-layer check a bogus verdict would land in JSON and then be
+// rejected by the CHECK, leaving a JSON-vs-index split-brain (the row is
+// invisible to every index-backed reader). Validating here lets create() fail
+// loudly and atomically — nothing is written to either store.
+const VERDICT_VALUES_SET = new Set(VERDICT_VALUES);
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -176,6 +187,26 @@ export class DomainStore {
     if (!TABLES_SET.has(source)) {
       const err = new Error(`wicked-testing: invalid source '${source}' — must be one of: ${TABLES.join(", ")}`);
       err.code = "ERR_INVALID_SOURCE";
+      throw err;
+    }
+  }
+
+  // Reject an out-of-enum verdict at the application layer BEFORE the
+  // dual-write. The verdicts.verdict CHECK constraint (migration 002) would
+  // reject it at the SQLite index, but create() writes canonical JSON first —
+  // so without this guard a bogus verdict produces a JSON-vs-index split-brain
+  // (drift_count++ + stderr, JSON has the row, index doesn't, get() returns
+  // null). Throwing here keeps both stores in agreement: nothing is written.
+  // Only enforced when a verdict value is actually supplied (the column is NOT
+  // NULL at the schema level, so a missing value is left to the DB insert; an
+  // explicit out-of-enum string is the fail-loud case the CHECK promises).
+  _assertVerdictValue(payload) {
+    if (payload == null || payload.verdict === undefined || payload.verdict === null) return;
+    if (!VERDICT_VALUES_SET.has(payload.verdict)) {
+      const err = new Error(
+        `wicked-testing: invalid verdict value '${payload.verdict}' — must be one of: ${VERDICT_VALUES.join(", ")}`
+      );
+      err.code = "ERR_INVALID_VERDICT";
       throw err;
     }
   }
@@ -344,6 +375,10 @@ export class DomainStore {
   // --- CRUD: create ---
   create(source, payload) {
     this._assertTable(source);
+    // Validate the verdict value against the enum BEFORE any write so an
+    // out-of-enum value fails loudly and atomically (no split-brain). See
+    // _assertVerdictValue. No-op for non-verdict tables.
+    if (source === "verdicts") this._assertVerdictValue(payload);
     const record = {
       id: payload.id || randomUUID(),
       ...payload,

--- a/lib/domain-store.mjs
+++ b/lib/domain-store.mjs
@@ -56,7 +56,12 @@ try {
 }
 
 // --- Constants ---
-const SCHEMA_VERSION = 1;
+// Bumped to 2 in migration 002 (verdict CHECK constraint + verdicts.equivalence_json).
+// This MUST track the highest migration version under lib/migrations/ — the
+// forward-compat lockout in _initDb() refuses to open a DB whose recorded
+// schema version exceeds this constant, so a stale value here would lock the
+// store out of its own freshly-migrated database.
+const SCHEMA_VERSION = 2;
 const TABLES = ["projects", "strategies", "scenarios", "runs", "verdicts", "tasks"];
 const TABLES_SET = new Set(TABLES);
 // Max age before a `runs` row stuck in 'running' is swept on init (1 hour).
@@ -81,7 +86,7 @@ const TABLE_COLUMNS = {
   strategies: ["id", "project_id", "name", "body", "created_at", "updated_at", "deleted", "deleted_at"],
   scenarios:  ["id", "project_id", "strategy_id", "name", "format_version", "body", "source_path", "created_at", "updated_at", "deleted", "deleted_at"],
   runs:       ["id", "project_id", "scenario_id", "started_at", "finished_at", "status", "evidence_path", "created_at", "updated_at", "deleted", "deleted_at"],
-  verdicts:   ["id", "run_id", "verdict", "evidence_path", "reviewer", "reason", "created_at", "updated_at", "deleted", "deleted_at"],
+  verdicts:   ["id", "run_id", "verdict", "evidence_path", "reviewer", "reason", "equivalence_json", "created_at", "updated_at", "deleted", "deleted_at"],
   tasks:      ["id", "project_id", "title", "body", "status", "assignee_skill", "created_at", "updated_at", "deleted", "deleted_at"],
 };
 

--- a/lib/manifest.mjs
+++ b/lib/manifest.mjs
@@ -79,7 +79,11 @@ function normalizeEquivalence(verdictRecord) {
   if (typeof raw.baseline_ref === "string" && raw.baseline_ref) out.baseline_ref = raw.baseline_ref;
   if (typeof raw.baseline_sha === "string" && /^[a-f0-9]{64}$/.test(raw.baseline_sha)) out.baseline_sha = raw.baseline_sha;
   if (Number.isInteger(raw.diff_count) && raw.diff_count >= 0) out.diff_count = raw.diff_count;
-  if (typeof raw.tolerance === "number" && raw.tolerance >= 0) out.tolerance = raw.tolerance;
+  // Require a FINITE number: `typeof x === "number"` also accepts Infinity/NaN,
+  // and `Infinity >= 0` is true — a non-finite tolerance would make any
+  // diff_count "within tolerance". Infinity/NaN also serialize to `null`, which
+  // violates the schema (number). Number.isFinite rejects both.
+  if (Number.isFinite(raw.tolerance) && raw.tolerance >= 0) out.tolerance = raw.tolerance;
   // Producer-enforced invariant (NIT-4): the facet is the "verdict of record"
   // for equivalence, so a self-contradictory facet is worse than no facet.
   // When BOTH diff_count and tolerance are present, `matched` must equal

--- a/lib/manifest.mjs
+++ b/lib/manifest.mjs
@@ -23,6 +23,15 @@ import { platform, release } from "node:os";
 // unaffected.
 export const MANIFEST_VERSION = "1.1.0";
 
+// Single source of truth for the verdict enum. MUST stay identical to
+// schemas/evidence.json `verdict.value` and the CHECK constraint in
+// lib/migrations/002_verdict_check_and_equivalence.sql. validateShape() below
+// and DomainStore's pre-write verdict guard (lib/domain-store.mjs) both import
+// this so there is exactly one place to update when the taxonomy changes.
+export const VERDICT_VALUES = Object.freeze([
+  "PASS", "FAIL", "PARTIAL", "CONDITIONAL", "INCONCLUSIVE", "N-A", "SKIP",
+]);
+
 // Artifact kind classification. Every artifact ends up with a kind from this
 // set because the schema's enum rejects anything else. Unknown extensions
 // fall through to "misc" rather than being dropped.
@@ -71,6 +80,14 @@ function normalizeEquivalence(verdictRecord) {
   if (typeof raw.baseline_sha === "string" && /^[a-f0-9]{64}$/.test(raw.baseline_sha)) out.baseline_sha = raw.baseline_sha;
   if (Number.isInteger(raw.diff_count) && raw.diff_count >= 0) out.diff_count = raw.diff_count;
   if (typeof raw.tolerance === "number" && raw.tolerance >= 0) out.tolerance = raw.tolerance;
+  // Producer-enforced invariant (NIT-4): the facet is the "verdict of record"
+  // for equivalence, so a self-contradictory facet is worse than no facet.
+  // When BOTH diff_count and tolerance are present, `matched` must equal
+  // `diff_count <= tolerance`; otherwise drop the facet (consistent with the
+  // "drop malformed → null" stance above) rather than persist a misleading one.
+  if ("diff_count" in out && "tolerance" in out && out.matched !== (out.diff_count <= out.tolerance)) {
+    return null;
+  }
   return out;
 }
 
@@ -189,7 +206,7 @@ function validateShape(m) {
   }
   if (!/^\d+\.\d+\.\d+$/.test(m.manifest_version)) throw new Error("manifest: invalid manifest_version");
   if (!["passed", "failed", "partial", "inconclusive", "errored", "skipped"].includes(m.status)) throw new Error(`manifest: invalid status '${m.status}'`);
-  if (!["PASS", "FAIL", "PARTIAL", "CONDITIONAL", "INCONCLUSIVE", "N-A", "SKIP"].includes(m.verdict.value)) throw new Error(`manifest: invalid verdict.value '${m.verdict.value}'`);
+  if (!VERDICT_VALUES.includes(m.verdict.value)) throw new Error(`manifest: invalid verdict.value '${m.verdict.value}'`);
   // Optional baseline-match facet: validate only when present. Mirrors
   // schemas/evidence.json verdict.equivalence (required method + matched).
   if ("equivalence" in m.verdict) {

--- a/lib/manifest.mjs
+++ b/lib/manifest.mjs
@@ -17,7 +17,11 @@ import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { platform, release } from "node:os";
 
-export const MANIFEST_VERSION = "1.0.0";
+// 1.1.0: added the optional verdict.equivalence facet (baseline-match
+// provenance). Minor bump per docs/EVIDENCE.md §7 — adds an optional field,
+// no existing field changed or removed, readers ignoring unknown keys are
+// unaffected.
+export const MANIFEST_VERSION = "1.1.0";
 
 // Artifact kind classification. Every artifact ends up with a kind from this
 // set because the schema's enum rejects anything else. Unknown extensions
@@ -43,11 +47,41 @@ function classifyArtifact(filename) {
   return "misc";
 }
 
+// Valid equivalence-method values — must match schemas/evidence.json
+// verdict.equivalence.method enum exactly.
+const EQUIVALENCE_METHODS = ["golden-master", "contract", "reconciliation", "perceptual"];
+
+// Coerce the optional baseline-match facet from a verdict record into the
+// manifest's verdict.equivalence shape (or null if absent / unusable). Accepts
+// either `equivalence` (object) or `equivalence_json` (JSON string from the DB
+// column). Only the schema-known keys are carried; a malformed/incomplete
+// facet returns null so the optional field is simply omitted rather than
+// producing an invalid manifest.
+function normalizeEquivalence(verdictRecord) {
+  let raw = verdictRecord.equivalence;
+  if (raw == null && typeof verdictRecord.equivalence_json === "string" && verdictRecord.equivalence_json.trim()) {
+    try { raw = JSON.parse(verdictRecord.equivalence_json); } catch { return null; }
+  }
+  if (!raw || typeof raw !== "object") return null;
+  // Required-by-schema fields. Without them the block can't validate, so drop it.
+  if (typeof raw.matched !== "boolean") return null;
+  if (!EQUIVALENCE_METHODS.includes(raw.method)) return null;
+  const out = { method: raw.method, matched: raw.matched };
+  if (typeof raw.baseline_ref === "string" && raw.baseline_ref) out.baseline_ref = raw.baseline_ref;
+  if (typeof raw.baseline_sha === "string" && /^[a-f0-9]{64}$/.test(raw.baseline_sha)) out.baseline_sha = raw.baseline_sha;
+  if (Number.isInteger(raw.diff_count) && raw.diff_count >= 0) out.diff_count = raw.diff_count;
+  if (typeof raw.tolerance === "number" && raw.tolerance >= 0) out.tolerance = raw.tolerance;
+  return out;
+}
+
 /**
  * @param {object} opts
  * @param {object} opts.runRecord      runs row: { id, project_id, scenario_id, started_at, finished_at, status, evidence_path }
  * @param {object} opts.scenarioRecord scenarios row: { id, name, source_path? }
- * @param {object} opts.verdictRecord  verdicts row: { verdict, reviewer, reason?, created_at }
+ * @param {object} opts.verdictRecord  verdicts row: { verdict, reviewer, reason?, created_at, equivalence_json?, equivalence? }
+ *   The optional baseline-match facet may arrive either as `equivalence` (a
+ *   plain object) or `equivalence_json` (the DB column — a JSON string). Either
+ *   form is normalized into the manifest's `verdict.equivalence` block.
  * @param {string} opts.evidenceDir    absolute path to the run's evidence dir
  * @param {string} opts.wickedTestingVersion  e.g. "0.2.0"
  * @param {string} [opts.cli]          optional host CLI name ("claude", "gemini", ...)
@@ -71,6 +105,12 @@ export function buildManifest({
 
   const artifacts = collectArtifacts(evidenceDir, excludeFiles);
 
+  // Normalize the optional baseline-match facet. Accept either a plain object
+  // (`equivalence`) or the DB column form (`equivalence_json`, a JSON string).
+  // A malformed JSON string is dropped rather than throwing — the facet is
+  // optional and a broken sidecar must not sink an otherwise-valid manifest.
+  const equivalence = normalizeEquivalence(verdictRecord);
+
   const started = runRecord.started_at ? new Date(runRecord.started_at).getTime() : null;
   const finished = runRecord.finished_at ? new Date(runRecord.finished_at).getTime() : null;
   const duration_ms = started !== null && finished !== null && finished >= started
@@ -93,6 +133,7 @@ export function buildManifest({
       reviewer: verdictRecord.reviewer || "unknown",
       ...(verdictRecord.reason ? { reason: verdictRecord.reason } : {}),
       recorded_at: verdictRecord.created_at || new Date().toISOString(),
+      ...(equivalence ? { equivalence } : {}),
     },
     environment: {
       os: `${platform()} ${release()}`,
@@ -148,7 +189,15 @@ function validateShape(m) {
   }
   if (!/^\d+\.\d+\.\d+$/.test(m.manifest_version)) throw new Error("manifest: invalid manifest_version");
   if (!["passed", "failed", "partial", "inconclusive", "errored", "skipped"].includes(m.status)) throw new Error(`manifest: invalid status '${m.status}'`);
-  if (!["PASS", "FAIL", "PARTIAL", "INCONCLUSIVE", "N-A", "SKIP"].includes(m.verdict.value)) throw new Error(`manifest: invalid verdict.value '${m.verdict.value}'`);
+  if (!["PASS", "FAIL", "PARTIAL", "CONDITIONAL", "INCONCLUSIVE", "N-A", "SKIP"].includes(m.verdict.value)) throw new Error(`manifest: invalid verdict.value '${m.verdict.value}'`);
+  // Optional baseline-match facet: validate only when present. Mirrors
+  // schemas/evidence.json verdict.equivalence (required method + matched).
+  if ("equivalence" in m.verdict) {
+    const eq = m.verdict.equivalence;
+    if (!eq || typeof eq !== "object") throw new Error("manifest: verdict.equivalence must be an object");
+    if (!EQUIVALENCE_METHODS.includes(eq.method)) throw new Error(`manifest: invalid verdict.equivalence.method '${eq.method}'`);
+    if (typeof eq.matched !== "boolean") throw new Error("manifest: verdict.equivalence.matched must be a boolean");
+  }
   if (!Array.isArray(m.artifacts)) throw new Error("manifest: artifacts must be array");
   for (const a of m.artifacts) {
     for (const k of ["name", "kind", "path", "bytes", "sha256", "captured_at"]) {

--- a/lib/migrations/002_verdict_check_and_equivalence.sql
+++ b/lib/migrations/002_verdict_check_and_equivalence.sql
@@ -1,0 +1,61 @@
+-- wicked-testing migration 002: verdict CHECK constraint + equivalence provenance
+-- Applied automatically by DomainStore (lib/migrate.mjs) in numeric order,
+-- inside its own transaction. Pure DDL — do NOT write into schema_migrations
+-- here; the runner records the version row after exec() succeeds.
+--
+-- Two changes, both additive / backward-compatible:
+--
+--   1. Add a CHECK constraint to verdicts.verdict so an out-of-enum value
+--      fails loudly at write time instead of silently landing a row that the
+--      public manifest (schemas/evidence.json + manifest.validateShape) would
+--      later reject. The enum matches the manifest verdict enum exactly,
+--      INCLUDING `CONDITIONAL` (added in this release — four Tier-2 agents
+--      already emit it). SQLite cannot ALTER TABLE ADD CONSTRAINT, so this is
+--      the documented 12-step table redefinition: build the new table, copy
+--      rows, drop the old, rename. Nothing references verdicts (the FK points
+--      FROM verdicts TO runs), so no child rows are orphaned by the rename.
+--
+--   2. Add a nullable equivalence_json column to carry the optional
+--      verdict.equivalence facet (baseline-match provenance) alongside the
+--      canonical JSON. Nullable + defaulted NULL ⇒ every existing row is valid
+--      and every existing reader is unaffected.
+--
+-- Backward compatibility: existing rows are copied verbatim. If a pre-existing
+-- row somehow holds a value outside the enum, the INSERT...SELECT below would
+-- fail the CHECK and abort the whole migration transaction (loud, safe, no
+-- partial state). The current shipped enum values (PASS/FAIL/PARTIAL/
+-- INCONCLUSIVE/N-A/SKIP) plus CONDITIONAL are all permitted, so a conformant
+-- v1 ledger migrates cleanly.
+
+-- Build the replacement table with the CHECK constraint. Column order and
+-- types match 001_initial.sql exactly, plus the new equivalence_json column.
+CREATE TABLE verdicts_new (
+  id              TEXT PRIMARY KEY,
+  run_id          TEXT NOT NULL REFERENCES runs(id),
+  verdict         TEXT NOT NULL CHECK (verdict IN (
+                    'PASS', 'FAIL', 'PARTIAL', 'CONDITIONAL', 'INCONCLUSIVE', 'N-A', 'SKIP'
+                  )),
+  evidence_path   TEXT,
+  reviewer        TEXT NOT NULL,
+  reason          TEXT,
+  equivalence_json TEXT,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL,
+  deleted         INTEGER NOT NULL DEFAULT 0,
+  deleted_at      TEXT
+);
+
+-- Copy every existing row. equivalence_json defaults to NULL for pre-existing
+-- rows (the column didn't exist before this migration).
+INSERT INTO verdicts_new (id, run_id, verdict, evidence_path, reviewer, reason, created_at, updated_at, deleted, deleted_at)
+SELECT id, run_id, verdict, evidence_path, reviewer, reason, created_at, updated_at, deleted, deleted_at
+FROM verdicts;
+
+DROP TABLE verdicts;
+
+ALTER TABLE verdicts_new RENAME TO verdicts;
+
+-- Recreate the indexes that lived on the old table (they were dropped with it).
+CREATE INDEX IF NOT EXISTS idx_verdicts_run ON verdicts(run_id);
+CREATE INDEX IF NOT EXISTS idx_verdicts_verdict ON verdicts(verdict);
+CREATE INDEX IF NOT EXISTS idx_verdicts_created_at ON verdicts(created_at);

--- a/lib/oracle-queries.mjs
+++ b/lib/oracle-queries.mjs
@@ -1,8 +1,8 @@
 /**
  * lib/oracle-queries.mjs — Fixed parameterized query library for test-oracle
  *
- * v1 ships 12 named queries. No LLM-generated SQL. Every query is auditable
- * by code review. Add new queries as code changes within v1 if AC demand it.
+ * Ships 13 named queries. No LLM-generated SQL. Every query is auditable
+ * by code review. Add new queries as code changes if AC demand it.
  *
  * Usage:
  *   import { getQuery, QUERY_NAMES, buildOracleQuery } from './oracle-queries.mjs';
@@ -193,6 +193,29 @@ export const QUERIES = {
     keywords: ["schema", "version", "migration"],
   },
 
+  baseline_matches_for_scenario: {
+    description: "Did scenario Y still match its captured baseline? (equivalence verdicts)",
+    params: ["scenario_name"],
+    // Only verdict rows that carry a baseline-match facet (equivalence_json
+    // non-null) are returned. The JSON is surfaced verbatim as
+    // `equivalence_json` for the oracle to parse — the fixed-SQL contract
+    // forbids JSON1 expression extraction in the query body, keeping every
+    // query a plain auditable SELECT.
+    sql: `
+      SELECT v.id, v.verdict, v.equivalence_json, v.created_at, v.reviewer, v.reason,
+             s.name as scenario_name, p.name as project_name
+      FROM verdicts v
+      JOIN runs r ON v.run_id = r.id
+      JOIN scenarios s ON r.scenario_id = s.id
+      JOIN projects p ON r.project_id = p.id
+      WHERE s.name = ?
+        AND v.equivalence_json IS NOT NULL
+        AND v.deleted = 0
+      ORDER BY v.created_at DESC
+    `,
+    keywords: ["baseline", "equivalence", "equivalent", "match", "matched", "reproduce", "reproduced", "golden", "reconcil"],
+  },
+
   most_recent_project: {
     description: "Most recently updated project",
     params: [],
@@ -246,6 +269,11 @@ export function routeQuestion(question, filters = {}) {
   }
 
   // Special-case disambiguation
+  // Baseline-match questions take priority over the generic verdict lookup —
+  // "did X still match the baseline?" is about equivalence, not the last verdict.
+  if (lower.includes("baseline") || lower.includes("equivalen") || lower.includes("golden master") || lower.includes("golden-master")) {
+    return "baseline_matches_for_scenario";
+  }
   if (lower.includes("last verdict") || lower.includes("latest verdict") || lower.includes("most recent verdict")) {
     return "last_verdict_for_scenario";
   }

--- a/lib/oracle-queries.mjs
+++ b/lib/oracle-queries.mjs
@@ -269,13 +269,26 @@ export function routeQuestion(question, filters = {}) {
   }
 
   // Special-case disambiguation
-  // Baseline-match questions take priority over the generic verdict lookup —
-  // "did X still match the baseline?" is about equivalence, not the last verdict.
-  if (lower.includes("baseline") || lower.includes("equivalen") || lower.includes("golden master") || lower.includes("golden-master")) {
-    return "baseline_matches_for_scenario";
-  }
+  // A last-verdict question wins even when the SCENARIO NAME happens to carry
+  // an equivalence noun (e.g. "last verdict for my golden-master scenario").
+  // This check is FIRST so the specific last-verdict intent is never shadowed
+  // by the broader equivalence route below.
   if (lower.includes("last verdict") || lower.includes("latest verdict") || lower.includes("most recent verdict")) {
     return "last_verdict_for_scenario";
+  }
+  // Baseline-match / equivalence route. Requires an explicit equivalence
+  // INTENT — a noun (baseline / equivalence / golden-master) AND a matching
+  // verb (match / reproduce / equivalent / reconcile) — rather than the bare
+  // noun substring. Gating on a verb keeps a generic "<verb-free> ... golden
+  // master scenario" question (often a last-verdict ask whose scenario merely
+  // mentions the noun) from misrouting here and returning empty.
+  const hasEquivalenceNoun =
+    lower.includes("baseline") || lower.includes("equivalen") ||
+    lower.includes("golden master") || lower.includes("golden-master");
+  const hasEquivalenceVerb =
+    /\b(match|matched|matches|reproduce|reproduced|reproduces|equivalent|equivalence|reconcile|reconciled)\b/.test(lower);
+  if (hasEquivalenceNoun && hasEquivalenceVerb) {
+    return "baseline_matches_for_scenario";
   }
   if (lower.includes("bootstrap")) {
     return "last_verdict_for_scenario";

--- a/schemas/evidence.json
+++ b/schemas/evidence.json
@@ -40,10 +40,24 @@
       "type": "object",
       "required": ["value", "reviewer", "recorded_at"],
       "properties": {
-        "value":    { "type": "string", "enum": ["PASS", "FAIL", "PARTIAL", "INCONCLUSIVE", "N-A", "SKIP"] },
+        "value":    { "type": "string", "enum": ["PASS", "FAIL", "PARTIAL", "CONDITIONAL", "INCONCLUSIVE", "N-A", "SKIP"] },
         "reviewer": { "type": "string", "minLength": 1 },
         "reason":   { "type": "string" },
-        "recorded_at": { "type": "string", "format": "date-time" }
+        "recorded_at": { "type": "string", "format": "date-time" },
+        "equivalence": {
+          "type": "object",
+          "description": "Optional baseline-match facet. Present when a behavior-preserving change was judged against a captured baseline (golden-master / contract / data-reconciliation / perceptual). A green run is not sufficient evidence of a faithful reproduction — this names the baseline-match as a typed, queryable fact.",
+          "required": ["method", "matched"],
+          "properties": {
+            "baseline_ref":  { "type": "string", "minLength": 1, "description": "Path or identifier of the captured baseline artifact." },
+            "baseline_sha":  { "type": "string", "pattern": "^[a-f0-9]{64}$", "description": "Lowercase hex SHA-256 of the baseline, for provenance." },
+            "method":        { "type": "string", "enum": ["golden-master", "contract", "reconciliation", "perceptual"] },
+            "diff_count":    { "type": "integer", "minimum": 0, "description": "Number of differences found vs. the baseline." },
+            "tolerance":     { "type": "number", "minimum": 0, "description": "Allowed diff threshold; matched is true when diff_count <= tolerance." },
+            "matched":       { "type": "boolean", "description": "Whether the fresh output matched the baseline within tolerance." }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": false
     },

--- a/skills/acceptance-testing/SKILL.md
+++ b/skills/acceptance-testing/SKILL.md
@@ -339,7 +339,11 @@ store.update('runs', run.id, {
 // no equivalence assertion — the facet is optional and backward-compatible.
 // (buildManifest below reads the same facet off the verdict record and lands
 // it in verdict.equivalence.)
-const reviewerEquivalence = reviewerEquivalenceFacet ?? null; // null unless an EQUIVALENT_TO_BASELINE assertion was evaluated
+// Source the optional facet from the same reviewer response that yields
+// `reviewerVerdict` / `reviewerSummary` (the reviewer agent's parsed output).
+// Absent unless the reviewer evaluated an EQUIVALENT_TO_BASELINE assertion.
+const reviewerEquivalenceFacet = reviewerResponse.equivalence ?? null;
+const reviewerEquivalence = reviewerEquivalenceFacet ?? null;
 const verdictRecord = store.create('verdicts', {
   run_id: run.id,
   verdict: reviewerVerdict,            // 'PASS' | 'FAIL' | 'PARTIAL' | 'CONDITIONAL' | 'INCONCLUSIVE'

--- a/skills/acceptance-testing/SKILL.md
+++ b/skills/acceptance-testing/SKILL.md
@@ -274,6 +274,9 @@ flag as CONTEXT_CONTAMINATION and return INCONCLUSIVE.)
 3. Read evidence files from the evidence directory (including context.md if present)
 4. Evaluate each assertion against evidence
 5. Return verdict: PASS | FAIL | INCONCLUSIVE
+6. For any EQUIVALENT_TO_BASELINE assertion, also return the equivalence facet
+   { baseline_ref, baseline_sha, method, diff_count, tolerance, matched } so the
+   orchestrator can persist it on the verdict (see `verdict.equivalence`).
 
 DO NOT reference any execution context beyond the files above.
 """
@@ -299,7 +302,14 @@ Two writes and one manifest build, in order:
 //   PASS         → passed
 //   FAIL         → failed
 //   PARTIAL      → partial         (some criteria met, some need human review)
+//   CONDITIONAL  → partial         (approve with listed fixes — Tier-2 gate verdict)
 //   INCONCLUSIVE → inconclusive    (evidence missing / context contaminated)
+//
+// CONDITIONAL is emitted by Tier-2 aggregator/gate agents (release-readiness,
+// security, ai-feature, test-code-quality). It is a deliberate "ship with
+// conditions" outcome — distinct from a clean PASS and from a FAIL — so it
+// maps to the `partial` run status rather than the `?? 'inconclusive'`
+// fallback (which is reserved for "couldn't evaluate").
 //
 // `errored` and `skipped` remain reachable only via the run lifecycle
 // (executor crash / stale-run sweep, all-steps-skipped) — never from a verdict.
@@ -307,6 +317,7 @@ const VERDICT_TO_STATUS = {
   PASS: 'passed',
   FAIL: 'failed',
   PARTIAL: 'partial',
+  CONDITIONAL: 'partial',
   INCONCLUSIVE: 'inconclusive',
 };
 const runStatus = VERDICT_TO_STATUS[reviewerVerdict] ?? 'inconclusive';
@@ -317,12 +328,25 @@ store.update('runs', run.id, {
 });
 
 // 2. Record verdict (triggers wicked.verdict.recorded emit)
+//
+// Optional baseline-match facet (rec #5): when the reviewer rendered an
+// EQUIVALENT_TO_BASELINE assertion it reports a `verdict.equivalence` object
+// { baseline_ref, baseline_sha, method, diff_count, tolerance, matched }.
+// Extract it from the reviewer's response (alongside reviewerVerdict /
+// reviewerSummary) and persist it as the `equivalence_json` column (JSON
+// string) so it survives in the ledger and is surfaced by the
+// `baseline_matches_for_scenario` oracle query. Leave it null when the run had
+// no equivalence assertion — the facet is optional and backward-compatible.
+// (buildManifest below reads the same facet off the verdict record and lands
+// it in verdict.equivalence.)
+const reviewerEquivalence = reviewerEquivalenceFacet ?? null; // null unless an EQUIVALENT_TO_BASELINE assertion was evaluated
 const verdictRecord = store.create('verdicts', {
   run_id: run.id,
-  verdict: reviewerVerdict,            // 'PASS' | 'FAIL' | 'PARTIAL' | 'INCONCLUSIVE'
+  verdict: reviewerVerdict,            // 'PASS' | 'FAIL' | 'PARTIAL' | 'CONDITIONAL' | 'INCONCLUSIVE'
   evidence_path: EVIDENCE_DIR,
   reviewer: 'acceptance-test-reviewer',
   reason: reviewerSummary,
+  ...(reviewerEquivalence ? { equivalence_json: JSON.stringify(reviewerEquivalence) } : {}),
 });
 
 // 3. Materialize the public manifest at the contract path

--- a/tests/unit/domain-store.test.mjs
+++ b/tests/unit/domain-store.test.mjs
@@ -195,3 +195,60 @@ test("rejects an unknown table name (allowlist guard)", () => {
     (err) => err.code === "ERR_INVALID_SOURCE"
   );
 });
+
+// --- CONDITIONAL verdict (rec #1): now a legal enum value end-to-end ---
+// Four Tier-2 agents (release-readiness, security, ai-feature, test-code-
+// quality) emit CONDITIONAL. Migration 002 added it to the verdicts.verdict
+// CHECK constraint, so the write must persist through the real store (which
+// opens the DB with foreign_keys = ON and the CHECK active) — not silently
+// fail the SQLite insert and drift to JSON-only.
+
+test("a CONDITIONAL verdict persists through the store (CHECK constraint accepts it)", () => {
+  const { run } = seedRunChain();
+  store.update("runs", run.id, { status: "partial", finished_at: new Date().toISOString() });
+  const verdict = store.create("verdicts", {
+    run_id: run.id,
+    verdict: "CONDITIONAL",
+    reviewer: "release-readiness-engineer",
+    reason: "ship with the two listed fixes",
+  });
+
+  // Index row + canonical JSON agree, and the row really landed in SQLite
+  // (drift_count stays 0 — a CHECK rejection would have bumped it and the
+  // index would diverge from JSON).
+  const fromIndex = store.get("verdicts", verdict.id);
+  const fromJson = readJsonRecord("verdicts", verdict.id);
+  assert.equal(fromIndex.verdict, "CONDITIONAL");
+  assert.equal(fromJson.verdict, "CONDITIONAL");
+  assert.equal(store.stats().drift_count, 0, "CONDITIONAL must NOT trip the CHECK constraint (no SQLite drift)");
+});
+
+// --- Equivalence facet (rec #5): equivalence_json column round-trips ---
+
+test("a verdict's equivalence_json (baseline-match facet) round-trips through index and JSON", () => {
+  const { run } = seedRunChain();
+  store.update("runs", run.id, { status: "partial", finished_at: new Date().toISOString() });
+  const equivalence_json = JSON.stringify({
+    baseline_ref: "tests/baselines/cart.json",
+    baseline_sha: "a".repeat(64),
+    method: "golden-master",
+    diff_count: 0,
+    tolerance: 0,
+    matched: true,
+  });
+  const verdict = store.create("verdicts", {
+    run_id: run.id,
+    verdict: "CONDITIONAL",
+    reviewer: "data-quality-tester",
+    reason: "matched baseline within tolerance",
+    equivalence_json,
+  });
+
+  const fromIndex = store.get("verdicts", verdict.id);
+  const fromJson = readJsonRecord("verdicts", verdict.id);
+  assert.equal(fromIndex.equivalence_json, equivalence_json, "equivalence_json must persist in the SQLite index");
+  assert.equal(fromJson.equivalence_json, equivalence_json, "equivalence_json must persist in the canonical JSON");
+  const eq = JSON.parse(fromIndex.equivalence_json);
+  assert.equal(eq.matched, true);
+  assert.equal(eq.method, "golden-master");
+});

--- a/tests/unit/domain-store.test.mjs
+++ b/tests/unit/domain-store.test.mjs
@@ -252,3 +252,61 @@ test("a verdict's equivalence_json (baseline-match facet) round-trips through in
   assert.equal(eq.matched, true);
   assert.equal(eq.method, "golden-master");
 });
+
+// --- MED-1 regression: an out-of-enum verdict fails LOUDLY and ATOMICALLY ---
+// Before the fix, create() wrote canonical JSON first, then _dbInsert swallowed
+// the CHECK-constraint failure (drift++ + stderr) — leaving the row in JSON but
+// NOT in the index (split-brain: get() returns null while JSON says it exists).
+// create() now validates the verdict against the enum (single source of truth,
+// lib/manifest.mjs VERDICT_VALUES) BEFORE any write and throws, so neither
+// store gets a dangling row.
+
+test("an out-of-enum verdict throws and leaves NO split-brain (neither JSON nor index)", () => {
+  const { run } = seedRunChain();
+  const bogusId = "bogus-verdict-id";
+
+  assert.throws(
+    () => store.create("verdicts", {
+      id: bogusId,
+      run_id: run.id,
+      verdict: "WONTFIX", // not in the enum
+      reviewer: "some-agent",
+      reason: "should never persist",
+    }),
+    (err) => err.code === "ERR_INVALID_VERDICT" && /WONTFIX/.test(err.message),
+    "create() must throw a clear ERR_INVALID_VERDICT for an out-of-enum verdict"
+  );
+
+  // No canonical JSON file was written (atomic: the throw is BEFORE the write).
+  const jsonPath = join(root, "verdicts", `${bogusId}.json`);
+  assert.equal(existsSync(jsonPath), false, "no canonical JSON row may exist for a rejected verdict");
+
+  // No index row either, and the failure did NOT register as drift (it was a
+  // clean pre-write rejection, not a swallowed CHECK violation).
+  assert.equal(store.get("verdicts", bogusId), null, "no index row may exist for a rejected verdict");
+  assert.equal(store.stats().drift_count, 0, "a rejected verdict must not count as dual-write drift");
+});
+
+test("every valid verdict value (incl. CONDITIONAL) persists and reads back from BOTH stores", () => {
+  const { run } = seedRunChain();
+  const FULL_ENUM = ["PASS", "FAIL", "PARTIAL", "CONDITIONAL", "INCONCLUSIVE", "N-A", "SKIP"];
+
+  for (const value of FULL_ENUM) {
+    const v = store.create("verdicts", {
+      run_id: run.id,
+      verdict: value,
+      reviewer: "acceptance-test-reviewer",
+      reason: `value=${value}`,
+    });
+    const fromIndex = store.get("verdicts", v.id);
+    const fromJson = readJsonRecord("verdicts", v.id);
+    assert.ok(fromIndex, `index row must exist for verdict '${value}'`);
+    assert.equal(fromIndex.verdict, value, `index verdict must be '${value}'`);
+    assert.equal(fromJson.verdict, value, `canonical JSON verdict must be '${value}'`);
+  }
+
+  // All seven landed in the index with no drift — the CHECK accepted every
+  // enum value and the pre-write guard let them all through.
+  assert.equal(store.stats().drift_count, 0, "no valid verdict may trip the CHECK / cause drift");
+  assert.equal(store.stats().counts.verdicts, FULL_ENUM.length, "every valid verdict must be indexed");
+});

--- a/tests/unit/manifest.test.mjs
+++ b/tests/unit/manifest.test.mjs
@@ -164,3 +164,40 @@ test("a consistent equivalence facet (matched === diff_count<=tolerance) is kept
   assert.equal(eq.diff_count, 2);
   assert.equal(eq.tolerance, 5);
 });
+
+// --- Gemini review: tolerance must be a FINITE number ---
+
+test("a non-finite tolerance (Infinity) is rejected, not carried onto the facet", () => {
+  // `typeof Infinity === "number"` and `Infinity >= 0` is true, so the old
+  // `typeof`-based guard would have accepted it — making any diff_count appear
+  // "within tolerance" — and Infinity serializes to null, violating the schema.
+  // Number.isFinite rejects it: the tolerance field is simply omitted. With
+  // tolerance gone the NIT-4 invariant (needs BOTH diff_count and tolerance)
+  // does not fire, so the rest of the facet is kept.
+  const { manifest } = buildManifest(
+    records({ verdict: "PASS", equivalence: { method: "golden-master", matched: true, diff_count: 0, tolerance: Infinity } })
+  );
+  const eq = manifest.verdict.equivalence;
+  assert.ok(eq, "the facet itself is still valid (matched + method present)");
+  assert.equal("tolerance" in eq, false, "a non-finite tolerance must not land on the manifest");
+  assert.equal(eq.diff_count, 0);
+});
+
+test("a NaN tolerance is rejected, not carried onto the facet", () => {
+  const { manifest } = buildManifest(
+    records({ verdict: "PASS", equivalence: { method: "perceptual", matched: true, diff_count: 1, tolerance: NaN } })
+  );
+  const eq = manifest.verdict.equivalence;
+  assert.ok(eq, "the facet itself is still valid");
+  assert.equal("tolerance" in eq, false, "a NaN tolerance must not land on the manifest");
+});
+
+test("an Infinity tolerance arriving via equivalence_json is dropped (JSON.parse yields null → not a finite number)", () => {
+  // JSON has no Infinity literal; producers serialize it as null. Number.isFinite(null)
+  // is false, so the tolerance is omitted regardless of the input form.
+  const equivalence_json = JSON.stringify({ method: "contract", matched: true, diff_count: 0, tolerance: Infinity });
+  const { manifest } = buildManifest(records({ verdict: "PASS", equivalence_json }));
+  const eq = manifest.verdict.equivalence;
+  assert.ok(eq, "facet parsed and kept");
+  assert.equal("tolerance" in eq, false, "null-serialized non-finite tolerance must not land on the manifest");
+});

--- a/tests/unit/manifest.test.mjs
+++ b/tests/unit/manifest.test.mjs
@@ -139,3 +139,28 @@ test("an equivalence facet with an out-of-enum method is dropped before it can f
   );
   assert.equal("equivalence" in manifest.verdict, false, "bad-method facet must be dropped, manifest still valid");
 });
+
+// --- NIT-4: producer-enforced invariant matched === (diff_count <= tolerance) ---
+
+test("an equivalence facet whose matched contradicts diff_count<=tolerance is dropped", () => {
+  // diff_count(3) > tolerance(0) but matched:true — self-contradictory; the
+  // facet is the verdict-of-record for equivalence, so a misleading one is
+  // worse than none. normalizeEquivalence drops it (consistent with its other
+  // drop-malformed paths) rather than persisting the contradiction.
+  const { manifest } = buildManifest(
+    records({ verdict: "PASS", equivalence: { method: "golden-master", matched: true, diff_count: 3, tolerance: 0 } })
+  );
+  assert.equal("equivalence" in manifest.verdict, false, "contradictory facet must be dropped");
+});
+
+test("a consistent equivalence facet (matched === diff_count<=tolerance) is kept", () => {
+  // diff_count(2) <= tolerance(5) and matched:true — consistent; kept.
+  const { manifest } = buildManifest(
+    records({ verdict: "PASS", equivalence: { method: "perceptual", matched: true, diff_count: 2, tolerance: 5 } })
+  );
+  const eq = manifest.verdict.equivalence;
+  assert.ok(eq, "a consistent facet must be kept");
+  assert.equal(eq.matched, true);
+  assert.equal(eq.diff_count, 2);
+  assert.equal(eq.tolerance, 5);
+});

--- a/tests/unit/manifest.test.mjs
+++ b/tests/unit/manifest.test.mjs
@@ -1,0 +1,141 @@
+/**
+ * tests/unit/manifest.test.mjs
+ *
+ * Trust-module test for the public evidence manifest builder (lib/manifest.mjs).
+ *
+ * Covers the two contract-widening changes this release makes to the manifest
+ * (which is the one artifact downstream consumers read):
+ *
+ *   1. `CONDITIONAL` is now a legal verdict value. Four Tier-2 agents already
+ *      emit it; before this change buildManifest()'s validateShape() threw
+ *      `invalid verdict.value 'CONDITIONAL'` the first time a manifest was
+ *      built off such a run. This proves it now passes.
+ *
+ *   2. The optional `verdict.equivalence` facet (baseline-match provenance)
+ *      flows through buildManifest from either input form — a plain
+ *      `equivalence` object OR the DB-column `equivalence_json` string — and
+ *      lands on the manifest. A malformed/incomplete facet is dropped (the
+ *      field is optional and a broken sidecar must not sink the manifest).
+ *
+ * validateShape is private; it's exercised through buildManifest (which calls
+ * it before writing). buildManifest writes manifest.json to disk, so each case
+ * uses a throwaway tmp evidence dir.
+ */
+
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildManifest, MANIFEST_VERSION } from "../../lib/manifest.mjs";
+
+let evidenceDir;
+
+beforeEach(() => {
+  evidenceDir = mkdtempSync(join(tmpdir(), "wt-manifest-"));
+});
+
+afterEach(() => {
+  rmSync(evidenceDir, { recursive: true, force: true });
+});
+
+// Minimal valid run/scenario records for buildManifest.
+function records(verdictOverrides = {}) {
+  return {
+    runRecord: {
+      id: "run-1",
+      project_id: "proj-1",
+      scenario_id: "scn-1",
+      started_at: "2026-06-01T00:00:00.000Z",
+      finished_at: "2026-06-01T00:00:03.000Z",
+      status: "partial",
+    },
+    scenarioRecord: { id: "scn-1", name: "cart-checkout-equivalence", source_path: "scenarios/cart.md" },
+    verdictRecord: {
+      verdict: "CONDITIONAL",
+      reviewer: "release-readiness-engineer",
+      reason: "ship with the two listed fixes",
+      created_at: "2026-06-01T00:00:03.000Z",
+      ...verdictOverrides,
+    },
+    evidenceDir,
+    wickedTestingVersion: "0.5.0",
+  };
+}
+
+test("manifest_version is the 1.1.x minor bump (equivalence facet added)", () => {
+  assert.match(MANIFEST_VERSION, /^1\.1\.\d+$/, `expected a 1.1.x manifest version, got ${MANIFEST_VERSION}`);
+});
+
+test("a CONDITIONAL verdict passes validateShape and is written to the manifest", () => {
+  const { manifest, path } = buildManifest(records());
+  assert.equal(manifest.verdict.value, "CONDITIONAL", "CONDITIONAL must survive validateShape");
+  assert.equal(manifest.status, "partial");
+  assert.ok(existsSync(path), "manifest.json must be written");
+  // And it round-trips from disk (validateShape didn't throw and write happened).
+  const onDisk = JSON.parse(readFileSync(path, "utf8"));
+  assert.equal(onDisk.verdict.value, "CONDITIONAL");
+});
+
+test("equivalence facet supplied as a plain object lands on verdict.equivalence", () => {
+  const { manifest } = buildManifest(
+    records({
+      equivalence: {
+        baseline_ref: "tests/baselines/cart.json",
+        baseline_sha: "a".repeat(64),
+        method: "golden-master",
+        diff_count: 0,
+        tolerance: 0,
+        matched: true,
+      },
+    })
+  );
+  const eq = manifest.verdict.equivalence;
+  assert.ok(eq, "verdict.equivalence must be present");
+  assert.equal(eq.method, "golden-master");
+  assert.equal(eq.matched, true);
+  assert.equal(eq.diff_count, 0);
+  assert.equal(eq.baseline_ref, "tests/baselines/cart.json");
+  assert.equal(eq.baseline_sha, "a".repeat(64));
+});
+
+test("equivalence facet supplied as equivalence_json (DB column) is parsed onto the manifest", () => {
+  const equivalence_json = JSON.stringify({
+    method: "reconciliation",
+    matched: false,
+    diff_count: 3,
+    tolerance: 0,
+  });
+  const { manifest } = buildManifest(records({ verdict: "FAIL", equivalence_json }));
+  const eq = manifest.verdict.equivalence;
+  assert.ok(eq, "verdict.equivalence must be parsed from equivalence_json");
+  assert.equal(eq.method, "reconciliation");
+  assert.equal(eq.matched, false);
+  assert.equal(eq.diff_count, 3);
+});
+
+test("verdict with NO equivalence facet omits the field entirely (backward-compatible)", () => {
+  const { manifest } = buildManifest(records({ verdict: "PASS" }));
+  assert.equal("equivalence" in manifest.verdict, false, "absent facet must not appear on the verdict");
+});
+
+test("a malformed equivalence_json string is dropped, not thrown (broken sidecar must not sink the manifest)", () => {
+  // Invalid JSON — normalizeEquivalence swallows the parse error and omits.
+  const { manifest } = buildManifest(records({ verdict: "PASS", equivalence_json: "{not valid json" }));
+  assert.equal("equivalence" in manifest.verdict, false, "unparseable facet is dropped silently");
+});
+
+test("an equivalence facet missing required keys is dropped (matched/method required by schema)", () => {
+  // No `matched`, no valid `method` → normalizeEquivalence returns null.
+  const { manifest } = buildManifest(records({ verdict: "PASS", equivalence: { diff_count: 0 } }));
+  assert.equal("equivalence" in manifest.verdict, false, "incomplete facet must be dropped");
+});
+
+test("an equivalence facet with an out-of-enum method is dropped before it can fail validateShape", () => {
+  // method not in the closed set; normalizeEquivalence rejects it so validateShape never sees it.
+  const { manifest } = buildManifest(
+    records({ verdict: "PASS", equivalence: { method: "fuzzy-vibes", matched: true } })
+  );
+  assert.equal("equivalence" in manifest.verdict, false, "bad-method facet must be dropped, manifest still valid");
+});

--- a/tests/unit/migrate.test.mjs
+++ b/tests/unit/migrate.test.mjs
@@ -1,0 +1,160 @@
+/**
+ * tests/unit/migrate.test.mjs
+ *
+ * Trust-module test for the versioned SQL migration runner (lib/migrate.mjs)
+ * and migration 002 (verdict CHECK constraint + verdicts.equivalence_json).
+ *
+ * The load-bearing claim under test: migration 002 must apply cleanly on a
+ * PRE-EXISTING v1 database (the upgrade path real users hit), not just on a
+ * fresh one. 002 redefines the `verdicts` table (SQLite can't ALTER TABLE ADD
+ * CONSTRAINT), so this proves the 12-step rebuild preserves existing rows,
+ * recreates the indexes, lands the new column, and enforces the CHECK — all
+ * with `foreign_keys = ON` (the runtime pragma DomainStore sets).
+ *
+ * Uses an in-memory better-sqlite3 db and reads the SQL files directly so the
+ * test is independent of DomainStore wiring. If better-sqlite3 can't load in
+ * this environment the whole file skips (matches the oracle-query test stance).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { readFileSync } from "node:fs";
+
+import { applyMigrations, listMigrations } from "../../lib/migrate.mjs";
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIG_DIR = join(__dirname, "..", "..", "lib", "migrations");
+
+let Database;
+try {
+  Database = require("better-sqlite3");
+} catch {
+  // SQLite unavailable in this environment — skip the whole file rather than
+  // fail. The migration logic is pure SQL; CI environments with the driver
+  // exercise it.
+  console.error("[migrate.test] better-sqlite3 unavailable — skipping migration tests");
+}
+
+const ISO = "2026-01-01T00:00:00.000Z";
+
+// Seed a v1-era project/scenario/run chain plus a single PASS verdict — the
+// only state a pre-002 ledger could legally hold.
+function seedV1Row(db) {
+  db.prepare("INSERT INTO projects (id,name,created_at,updated_at,deleted) VALUES (?,?,?,?,0)").run("p1", "proj", ISO, ISO);
+  db.prepare("INSERT INTO scenarios (id,project_id,name,format_version,created_at,updated_at,deleted) VALUES (?,?,?,?,?,?,0)").run("s1", "p1", "sc", "1.0", ISO, ISO);
+  db.prepare("INSERT INTO runs (id,project_id,scenario_id,started_at,status,created_at,updated_at,deleted) VALUES (?,?,?,?,?,?,?,0)").run("r1", "p1", "s1", ISO, "passed", ISO, ISO);
+  db.prepare("INSERT INTO verdicts (id,run_id,verdict,reviewer,created_at,updated_at,deleted) VALUES (?,?,?,?,?,?,0)").run("v1", "r1", "PASS", "rev", ISO, ISO);
+}
+
+test("listMigrations discovers 001 + 002 in numeric order", { skip: !Database }, () => {
+  const list = listMigrations(MIG_DIR);
+  const versions = list.map((m) => m.version);
+  assert.ok(versions.includes(1), "001 must be discoverable");
+  assert.ok(versions.includes(2), "002 must be discoverable");
+  // Sorted ascending by version.
+  assert.deepEqual(versions, [...versions].sort((a, b) => a - b));
+});
+
+test("applyMigrations on a FRESH db brings schema to v2 and creates equivalence_json", { skip: !Database }, () => {
+  const db = new Database(":memory:");
+  try {
+    db.pragma("foreign_keys = ON");
+    const results = applyMigrations(db, MIG_DIR);
+    // Both migrations applied (none pre-existing on a fresh db).
+    assert.deepEqual(results.map((r) => r.status), ["applied", "applied"]);
+    const ver = db.prepare("SELECT MAX(version) v FROM schema_migrations").get().v;
+    assert.equal(ver, 2, "fresh db should land at schema version 2");
+    // The equivalence_json column exists on verdicts.
+    const cols = db.prepare("PRAGMA table_info(verdicts)").all().map((c) => c.name);
+    assert.ok(cols.includes("equivalence_json"), "verdicts.equivalence_json must exist after 002");
+  } finally {
+    db.close();
+  }
+});
+
+test("002 applies cleanly on a PRE-EXISTING v1 db (the upgrade path) and preserves rows", { skip: !Database }, () => {
+  const db = new Database(":memory:");
+  try {
+    db.pragma("foreign_keys = ON");
+
+    // --- Build a v1 db: apply ONLY 001, mark version 1 applied (mirrors a
+    // ledger created before 002 shipped). ---
+    db.exec(readFileSync(join(MIG_DIR, "001_initial.sql"), "utf8"));
+    assert.equal(db.prepare("SELECT MAX(version) v FROM schema_migrations").get().v, 1);
+    seedV1Row(db);
+
+    // --- Now run the runner: it must see v1 applied, SKIP 001, and APPLY 002. ---
+    const results = applyMigrations(db, MIG_DIR);
+    const byVersion = Object.fromEntries(results.map((r) => [r.version, r.status]));
+    assert.equal(byVersion[1], "already_applied", "001 must be skipped on a v1 db (no re-exec)");
+    assert.equal(byVersion[2], "applied", "002 must be applied to upgrade v1 → v2");
+    assert.equal(db.prepare("SELECT MAX(version) v FROM schema_migrations").get().v, 2);
+
+    // --- The pre-existing row survives verbatim; the new column is NULL on it. ---
+    const row = db.prepare("SELECT * FROM verdicts WHERE id = ?").get("v1");
+    assert.equal(row.verdict, "PASS");
+    assert.equal(row.reviewer, "rev");
+    assert.equal(row.equivalence_json, null, "legacy row's new column defaults to NULL");
+
+    // --- Indexes that lived on the old table were recreated. ---
+    const idx = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'verdicts' AND name LIKE 'idx_%'")
+      .all()
+      .map((r) => r.name)
+      .sort();
+    assert.deepEqual(idx, ["idx_verdicts_created_at", "idx_verdicts_run", "idx_verdicts_verdict"]);
+
+    // --- The DROP/RENAME left no orphaned FKs (verdicts.run_id → runs.id). ---
+    const fk = db.pragma("foreign_key_check", { simple: false });
+    assert.ok(Array.isArray(fk) && fk.length === 0, "no FK violations after the table redefinition");
+  } finally {
+    db.close();
+  }
+});
+
+test("002 CHECK constraint accepts the full enum (incl. CONDITIONAL) and rejects out-of-enum", { skip: !Database }, () => {
+  const db = new Database(":memory:");
+  try {
+    db.pragma("foreign_keys = ON");
+    applyMigrations(db, MIG_DIR);
+    seedV1Row(db); // p1/s1/r1 exist; v1 already inserted as PASS
+
+    const FULL_ENUM = ["PASS", "FAIL", "PARTIAL", "CONDITIONAL", "INCONCLUSIVE", "N-A", "SKIP"];
+    let i = 0;
+    for (const v of FULL_ENUM) {
+      // PASS (v1) is already present; insert the rest under fresh ids.
+      const id = `enum-${i++}`;
+      assert.doesNotThrow(
+        () => db.prepare("INSERT INTO verdicts (id,run_id,verdict,reviewer,created_at,updated_at,deleted) VALUES (?,?,?,?,?,?,0)").run(id, "r1", v, "rev", ISO, ISO),
+        `CHECK must accept enum value '${v}'`
+      );
+    }
+
+    assert.throws(
+      () => db.prepare("INSERT INTO verdicts (id,run_id,verdict,reviewer,created_at,updated_at,deleted) VALUES (?,?,?,?,?,?,0)").run("bad", "r1", "BOGUS", "rev", ISO, ISO),
+      (e) => /CONSTRAINT/i.test(e.code || "") || /CHECK/i.test(e.message),
+      "CHECK must reject a value outside the enum"
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test("applyMigrations is idempotent — a second run applies nothing", { skip: !Database }, () => {
+  const db = new Database(":memory:");
+  try {
+    db.pragma("foreign_keys = ON");
+    applyMigrations(db, MIG_DIR);
+    const second = applyMigrations(db, MIG_DIR);
+    assert.ok(
+      second.every((r) => r.status === "already_applied"),
+      "re-running the runner must not re-apply any migration"
+    );
+  } finally {
+    db.close();
+  }
+});

--- a/tests/unit/oracle-queries.test.mjs
+++ b/tests/unit/oracle-queries.test.mjs
@@ -26,7 +26,7 @@ import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 
 import {
   QUERIES,
@@ -55,12 +55,13 @@ const EXPECTED_QUERY_NAMES = [
   "row_counts",
   "schema_version",
   "most_recent_project",
+  "baseline_matches_for_scenario",
 ];
 
-// --- The closed set is exactly 12 named queries ---
+// --- The closed set is exactly 13 named queries ---
 
-test("ships exactly the 12 documented named queries — no more, no fewer", () => {
-  assert.equal(QUERY_NAMES.length, 12, `expected 12 fixed queries, got ${QUERY_NAMES.length}`);
+test("ships exactly the 13 documented named queries — no more, no fewer", () => {
+  assert.equal(QUERY_NAMES.length, 13, `expected 13 fixed queries, got ${QUERY_NAMES.length}`);
   assert.deepEqual([...QUERY_NAMES].sort(), [...EXPECTED_QUERY_NAMES].sort());
 });
 
@@ -129,7 +130,7 @@ test("buildOracleQuery returns null for an unknown query name (cannot invent SQL
   assert.equal(buildOracleQuery("totally_made_up_query", {}), null);
 });
 
-test("supportedPatterns lists all 12 query descriptions", () => {
+test("supportedPatterns lists all 13 query descriptions", () => {
   const text = supportedPatterns();
   for (const name of EXPECTED_QUERY_NAMES) {
     assert.match(text, new RegExp(name), `supportedPatterns missing ${name}`);
@@ -140,8 +141,13 @@ test("supportedPatterns lists all 12 query descriptions", () => {
 
 function seededDb() {
   const db = new Database(":memory:");
-  const migration = readFileSync(join(__dirname, "..", "..", "lib", "migrations", "001_initial.sql"), "utf8");
-  db.exec(migration);
+  // Apply every migration in numeric order so the seeded schema matches the
+  // real DB (including 002's verdict CHECK + equivalence_json column). Reading
+  // the files directly keeps this test independent of the migration runner.
+  const migDir = join(__dirname, "..", "..", "lib", "migrations");
+  for (const f of readdirSync(migDir).filter(x => /^\d+_.+\.sql$/.test(x)).sort()) {
+    db.exec(readFileSync(join(migDir, f), "utf8"));
+  }
 
   const iso = "2026-06-01T00:00:00.000Z";
   db.prepare("INSERT INTO projects (id,name,description,created_at,updated_at,deleted) VALUES (?,?,?,?,?,0)")
@@ -152,6 +158,29 @@ function seededDb() {
     .run("r1", "p1", "s1", iso, "inconclusive", iso, iso);
   db.prepare("INSERT INTO verdicts (id,run_id,verdict,reviewer,reason,created_at,updated_at,deleted) VALUES (?,?,?,?,?,?,?,0)")
     .run("v1", "r1", "INCONCLUSIVE", "acceptance-test-reviewer", "evidence missing", iso, iso);
+  return db;
+}
+
+// Seed a project/scenario/run plus a CONDITIONAL verdict that carries a
+// baseline-match facet (equivalence_json). Used by the equivalence-oracle
+// tests below.
+function seededDbWithEquivalence() {
+  const db = seededDb();
+  const iso = "2026-06-02T00:00:00.000Z";
+  db.prepare("INSERT INTO scenarios (id,project_id,name,format_version,created_at,updated_at,deleted) VALUES (?,?,?,?,?,?,0)")
+    .run("s2", "p1", "cart-checkout-equivalence", "1.0", iso, iso);
+  db.prepare("INSERT INTO runs (id,project_id,scenario_id,started_at,status,created_at,updated_at,deleted) VALUES (?,?,?,?,?,?,?,0)")
+    .run("r2", "p1", "s2", iso, "partial", iso, iso);
+  const eq = JSON.stringify({
+    baseline_ref: "tests/baselines/cart.json",
+    baseline_sha: "a".repeat(64),
+    method: "golden-master",
+    diff_count: 0,
+    tolerance: 0,
+    matched: true,
+  });
+  db.prepare("INSERT INTO verdicts (id,run_id,verdict,reviewer,reason,equivalence_json,created_at,updated_at,deleted) VALUES (?,?,?,?,?,?,?,?,0)")
+    .run("v2", "r2", "CONDITIONAL", "data-quality-tester", "matched baseline within tolerance", eq, iso, iso);
   return db;
 }
 
@@ -209,5 +238,51 @@ test("recent_runs with project filter binds both params and runs", () => {
     assert.equal(rows[0].project_name, "demo");
   } finally {
     db.close();
+  }
+});
+
+// --- Equivalence / baseline-match oracle query (R1) ---
+
+test("baseline_matches_for_scenario returns only verdicts carrying an equivalence facet", () => {
+  const db = seededDbWithEquivalence();
+  try {
+    const { sql, params } = buildOracleQuery("baseline_matches_for_scenario", {
+      scenario_name: "cart-checkout-equivalence",
+    });
+    assert.deepEqual(params, ["cart-checkout-equivalence"]);
+    const rows = db.prepare(sql).all(...params);
+    assert.equal(rows.length, 1, "exactly the one equivalence verdict is returned");
+    const row = rows[0];
+    assert.equal(row.scenario_name, "cart-checkout-equivalence");
+    assert.equal(row.verdict, "CONDITIONAL");
+    assert.ok(row.equivalence_json, "equivalence_json is surfaced for the oracle to parse");
+    const eq = JSON.parse(row.equivalence_json);
+    assert.equal(eq.matched, true);
+    assert.equal(eq.method, "golden-master");
+    assert.equal(eq.diff_count, 0);
+  } finally {
+    db.close();
+  }
+});
+
+test("baseline_matches_for_scenario excludes non-equivalence verdicts (equivalence_json IS NULL)", () => {
+  const db = seededDbWithEquivalence();
+  try {
+    // scenario "login" has only a plain INCONCLUSIVE verdict (no equivalence facet).
+    const { sql, params } = buildOracleQuery("baseline_matches_for_scenario", { scenario_name: "login" });
+    const rows = db.prepare(sql).all(...params);
+    assert.equal(rows.length, 0, "a verdict without a baseline facet must not appear here");
+  } finally {
+    db.close();
+  }
+});
+
+test("routeQuestion sends baseline / equivalence questions to baseline_matches_for_scenario", () => {
+  for (const q of [
+    "did the cart scenario still match its baseline?",
+    "show me equivalence results for checkout",
+    "what reproduced the golden master?",
+  ]) {
+    assert.equal(routeQuestion(q), "baseline_matches_for_scenario", `routing failed for: ${q}`);
   }
 });

--- a/tests/unit/oracle-queries.test.mjs
+++ b/tests/unit/oracle-queries.test.mjs
@@ -286,3 +286,36 @@ test("routeQuestion sends baseline / equivalence questions to baseline_matches_f
     assert.equal(routeQuestion(q), "baseline_matches_for_scenario", `routing failed for: ${q}`);
   }
 });
+
+// --- MED-2 regression: a "last verdict" question must NOT misroute to the
+// equivalence query just because the SCENARIO NAME carries an equivalence noun
+// (baseline / golden-master / equivalence). The specific last-verdict route
+// wins; the equivalence route only fires on an explicit equivalence INTENT
+// (noun + verb). ---
+
+test("a 'last verdict' question for a baseline-named scenario routes to last_verdict_for_scenario", () => {
+  for (const q of [
+    "show me the last verdict for my golden master scenario",
+    "most recent verdict for baseline-cart",
+    "what is the latest verdict for the equivalence-cart scenario?",
+  ]) {
+    assert.equal(
+      routeQuestion(q),
+      "last_verdict_for_scenario",
+      `last-verdict intent must win even when the scenario name mentions equivalence: ${q}`
+    );
+  }
+});
+
+test("an explicit baseline/equivalence question (noun + verb) still routes to baseline_matches_for_scenario", () => {
+  for (const q of [
+    "did baseline-cart still match its baseline?",
+    "show the equivalence results — did checkout reproduce the golden master?",
+  ]) {
+    assert.equal(
+      routeQuestion(q),
+      "baseline_matches_for_scenario",
+      `explicit equivalence intent must route to the equivalence query: ${q}`
+    );
+  }
+});


### PR DESCRIPTION
From a cross-pollination review against the Migration Factory (Validate-stage concepts).

## Changes
- **Bug fix:** add `CONDITIONAL` to the verdict enum (`schemas/evidence.json`, `lib/manifest.mjs`). Four Tier-2 agents already emit CONDITIONAL but it was absent from the manifest enum, so `validateShape` threw on manifest build. Migration `002_verdict_check_and_equivalence.sql` adds a CHECK over the full enum.
- **Equivalence facet:** optional `verdict.equivalence` block + `EQUIVALENT_TO_BASELINE` reviewer operator + scenario `baseline:` support + `baseline_matches_for_scenario` oracle query ("green build ≠ faithful migration").

## Tests (independently re-verified)
- `npm test` (validate + version-sync schema gate) → exit 0
- `npm run test:unit` → **66/66 pass** (was 51); migration 002 verified on a pre-existing v1 db (rows preserved, CHECK accepts CONDITIONAL, rejects bogus)

Backward-compatible (optional/defaulted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
