### PR TITLE
docs(verdict): document additive-field policy for strict schema consumers (NIT-5)

### DIFF
--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -201,3 +201,39 @@ internal index — consumers get stable answers without depending on the schema.
 - Readers should ignore unknown fields for forward compatibility.
 - The path structure (`<project-root>/.wicked-testing/evidence/<run-id>/`) is
   stable across minor versions.
+
+### Additive-field policy (and what strict consumers must expect)
+
+The manifest — including the nested `verdict` object — grows **additively**:
+
+- A **minor** `manifest_version` bump (e.g. `1.0.0` → `1.1.0`, which added the
+  optional `verdict.equivalence` facet) only ever **adds optional fields**. No
+  existing field is renamed, retyped, or removed.
+- Only a **major** bump may change or remove a field.
+
+`schemas/evidence.json` declares `additionalProperties: false` on the manifest
+and on `verdict`. That constraint is a **producer-integrity guard** — it keeps
+wicked-testing from silently emitting undocumented keys — **not** a contract
+that downstream validators should mirror unchanged. A strict external validator
+that vendors a copy of the schema and enforces `additionalProperties: false`
+will **falsely reject** a manifest from a newer producer the moment a new
+optional field is introduced (exactly what would happen to a `1.0.0`-schema
+consumer seeing a `1.1.0` payload carrying `equivalence`).
+
+**Minimum expectation for a strict / vendored-schema consumer:**
+
+1. **Gate on `manifest_version`.** Read the major version; accept any payload
+   whose major matches the schema you hold. A higher *minor* is forward-
+   compatible — process it, do not reject it.
+2. **Ignore unknown fields.** Either relax `additionalProperties` to `true`
+   (or remove it) in your vendored copy, or run your validator in a mode that
+   warns-but-passes on extra keys. Never hard-fail on an unrecognized field
+   below a matching major version.
+3. **Only fail closed on a major-version mismatch** or a missing/invalid
+   *required* field — never on the mere presence of an additive optional field.
+
+The internal producer validator (`lib/manifest.mjs` `validateShape`)
+deliberately checks required fields + known-field types and does **not** reject
+unknown keys, so it already follows this same additive contract; the published
+`additionalProperties: false` is retained purely to keep the producer's own
+output honest.

--- a/schemas/evidence.json
+++ b/schemas/evidence.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mikeparcewski/wicked-testing/schemas/evidence.json",
   "title": "wicked-testing evidence manifest",
-  "description": "Public manifest schema for .wicked-testing/evidence/<run-id>/manifest.json. See docs/EVIDENCE.md.",
+  "description": "Public manifest schema for .wicked-testing/evidence/<run-id>/manifest.json. See docs/EVIDENCE.md. ADDITIVE-FIELD POLICY: this schema (and its nested objects) sets `additionalProperties: false` for producer integrity. The manifest grows additively under `manifest_version` semver — minor bumps add optional fields only (docs/EVIDENCE.md §7). Consumers validating against a vendored copy of this schema MUST gate on `manifest_version` and ignore unknown fields rather than reject them; do not enforce `additionalProperties: false` against payloads carrying a higher minor `manifest_version` than the schema copy you hold.",
   "type": "object",
   "required": [
     "manifest_version",
@@ -38,6 +38,7 @@
     },
     "verdict": {
       "type": "object",
+      "description": "The recorded verdict. `additionalProperties: false` here is a PRODUCER-INTEGRITY guard, not a consumer contract: it stops wicked-testing from silently emitting unknown keys. The manifest evolves ADDITIVELY under `manifest_version` (semver) — minor bumps add OPTIONAL fields and never change or remove existing ones (see docs/EVIDENCE.md §7). STRICT external validators MUST NOT vendor this `additionalProperties: false` verbatim against payloads from a newer producer; gate on `manifest_version` and ignore unknown fields instead, or a future additive field (as `equivalence` was in 1.1.0) will be falsely rejected.",
       "required": ["value", "reviewer", "recorded_at"],
       "properties": {
         "value":    { "type": "string", "enum": ["PASS", "FAIL", "PARTIAL", "CONDITIONAL", "INCONCLUSIVE", "N-A", "SKIP"] },


### PR DESCRIPTION
## NIT-5 — verdict object `additionalProperties: false` vs. strict external consumers

The `verdict` object schema (and the manifest root) declare `additionalProperties: false`. That protects **producer** integrity, but a **strict external validator** holding an older vendored schema copy will falsely reject a newer payload the moment an additive optional field appears — exactly the case when `verdict.equivalence` was added in `manifest_version` 1.1.0. The review marked this "None required for merge"; `EVIDENCE.md §7` already documented minor-bump / ignore-unknown-fields semantics.

### Decision — option (a): document the contract, do not weaken validation
A single vendored JSON Schema cannot be both *closed* for the producer and *open* for a different consumer audience — `additionalProperties` is a property of the document, not the validation mode. The correct small fix is to **keep `additionalProperties: false` for internal integrity** and **document the additive-field contract + minimum consumer expectation**.

### Changes (docs/schema annotations only — no code, no validation-semantics change)
- **`schemas/evidence.json`** — added a `description` on the `verdict` object and on the top-level schema naming the additive-field policy and the minimum consumer expectation (gate on `manifest_version`, ignore unknown fields, fail closed only on a *major*-version mismatch). `additionalProperties: false` remains `false` at root and on `verdict` (verified).
- **`docs/EVIDENCE.md §7`** — promoted the existing "ignore unknown fields" line into a named **Additive-field policy** section with a 3-point minimum consumer expectation, and noted that the internal producer validator (`lib/manifest.mjs` `validateShape`) already follows the same additive contract (checks required + known-field types, never rejects unknown keys).

### Internal integrity
`lib/manifest.mjs` `validateShape` is **untouched**. No code changed.

### Tests
- `npm test` — validate 0 errors / 0 warnings, plugin-version sync OK
- `npm run test:unit` — **75 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)